### PR TITLE
Fix imports for DDP example in README.md

### DIFF
--- a/distributed_shampoo/README.md
+++ b/distributed_shampoo/README.md
@@ -258,7 +258,7 @@ import torch
 import torch.distributed as dist
 
 from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import AdamGraftingConfig, DDPShampooConfig
+from distributed_shampoo.shampoo_types import AdamGraftingConfig, DDPShampooConfig, CommunicationDType
 from torch import nn
 
 LOCAL_RANK = int(os.environ["LOCAL_RANK"])


### PR DESCRIPTION
In the DDP example, `DDPShampooConfig` is using enum `CommunicationDType` which needs to be imported from `distributed_shampoo.shampoo_types`