### PR TITLE
[examples] Fix typo in ddp_cifar10_example.py

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
         raise ValueError(
             "Distributed checkpointing is only supported with DistributedShampoo!"
         )
-    if args.se_distributed_checkpoint and args.checkpoint_dir is None:
+    if args.use_distributed_checkpoint and args.checkpoint_dir is None:
         raise ValueError(
             "Trying to use distributed checkpointing but checkpoint directory is not provided!"
         )


### PR DESCRIPTION
This PR fixes a typo: `se_distributed_checkpoint ` -> `use_distributed_checkpoint`.
