### PR TITLE
[Prototype] Add param-to-lr interface to distributed Shampoo

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
         raise ValueError(
             "Distributed checkpointing is only supported with DistributedShampoo!"
         )
-    if args.se_distributed_checkpoint and args.checkpoint_dir is None:
+    if args.use_distributed_checkpoint and args.checkpoint_dir is None:
         raise ValueError(
             "Trying to use distributed checkpointing but checkpoint directory is not provided!"
         )

--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -131,6 +131,12 @@ if __name__ == "__main__":
         ),
         use_protected_eigh=args.use_protected_eigh,
         track_root_inv_residuals=args.track_root_inv_residuals,
+        experimental_lrs=(
+            [float(f) for f in args.experimental_lrs.split(",")]
+            if args.experimental_lrs
+            else []
+        ),
+        experimental_param_to_lr_mapping=args.experimental_param_to_lr_mapping,
     )
 
     # checks for checkpointing


### PR DESCRIPTION

## Summary

This PR prototypes a distributed Shampoo optimizer that efficiently executes a model with multiple parameter groups, each having different learning rates.

### Problem

PyTorch's optimizer assumes one learning rate per parameter group. To achieve different learning rates for different parameters, we need to create many parameter groups. However, the current Distributed Shampoo implementation cannot handle this efficiently because AllGather occurs per parameter group, leading to too fine-grained communication that hurts performance.

### Proposal (Prototype)

This prototype introduces a new interface that allows mapping parameters to learning rates using a function. This experimental interface enables developers to use a single parameter group while still applying different learning rates to different parameters.

#### Limitations

it's important to note that this is a prototype and has some fundamental problems:

- Unusual optimizer interface
- Burden of providing a mapping function for users
- Lack of checkpointing support (not tested)
- No proper unit tests
- PT2 is not supported (not tested)
- No performance test has been conducted.

## Testing

The DDP Cifar10 example was modified to test this feature.

```
COMMON_ARGS="-m distributed_shampoo.examples.ddp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 100 --grafting-type ADAM --num-trainers-per-group -1 --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 5 --local-batch-size 128"
```

**Learning rates for different params**
`--experimental-lrs=lr0,lr1,lr2,...` is the new benchmark interface to set learning rates for different parameters (currently in a round-robin manner). The correctness of `--experimental-lrs` is tested as follows:

1. Both `--experimental-lrs=0.1,0.1` and `--lr=0.1` on a single trainer return the same local lifetime loss
2. `--experimental-lrs=0.1,0.2` returns a different local lifetime loss.

```
$ torchrun --standalone --nnodes=1 --nproc_per_node=1 ${COMMON_ARGS} --lr="0.1"
...
INFO: Epoch: 4 | Iteration: 1955 | Local Lifetime Loss: 55.04213333129883 | Local Window Loss: 112.79435729980469

$ torchrun --standalone --nnodes=1 --nproc_per_node=1 ${COMMON_ARGS} --experimental-lrs="0.1,0.1"
...
INFO: Epoch: 4 | Iteration: 1955 | Local Lifetime Loss: 55.04213333129883 | Local Window Loss: 112.79435729980469

$ torchrun --standalone --nnodes=1 --nproc_per_node=1 ${COMMON_ARGS} --experimental-lrs="0.1,0.2"
...
INFO: Epoch: 4 | Iteration: 1955 | Local Lifetime Loss: 115.76996612548828 | Local Window Loss: 249.4604034423828
```


**New interface (proposed by this PR)** 
Setting `experimental_param_to_lr_mapping` allows the benchmark to create only one parameter group, which should be more efficient in terms of communication. The correctness of `--experimental-param-to-lr-mapping` is tested as follows

1. With `--experimental-lrs=0.1,0.2`, the local lifetime loss is the same with and without `--experimental_param_to_lr_mapping=1` on a single trainer.
```
$ torchrun --standalone --nnodes=1 --nproc_per_node=1 ${COMMON_ARGS} --experimental-lrs="0.1,0.2" --experimental-param-to-lr-mapping=1
...
INFO: Epoch: 4 | Iteration: 1955 | Local Lifetime Loss: 115.76996612548828 | Local Window Loss: 249.4604034423828

$ torchrun --standalone --nnodes=1 --nproc_per_node=1 ${COMMON_ARGS} --experimental-lrs="0.1,0.2" --experimental-param-to-lr-mapping=0
...
INFO: Epoch: 4 | Iteration: 1955 | Local Lifetime Loss: 115.76996612548828 | Local Window Loss: 249.4604034423828
```

2. Multiple trainers.  All the following matched the results (2 trainers).
```
$ torchrun --standalone --nnodes=1 --nproc_per_node=2 ${COMMON_ARGS} --lr=0.1
...
Epoch: 4 | Iteration: 980 | Global Lifetime Loss: 53.14086151123047 | Global Window Loss: 4.617415428161621 

$ torchrun --standalone --nnodes=1 --nproc_per_node=2 ${COMMON_ARGS} --experimental-lrs="0.1,0.1" --experimental-param-to-lr-mapping=1
...
Epoch: 4 | Iteration: 980 | Global Lifetime Loss: 53.14086151123047 | Global Window Loss: 4.617415428161621 

$ torchrun --standalone --nnodes=1 --nproc_per_node=2 ${COMMON_ARGS} --experimental-lrs="0.1,0.1" --experimental-param-to-lr-mapping=0
...
Epoch: 4 | Iteration: 980 | Global Lifetime Loss: 53.14086151123047 | Global Window Loss: 4.617415428161621
```
