### PR TITLE
Fix `EigenvalueCorrectedShampooPreconditionerListTest`

### DIFF
--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -74,9 +74,13 @@ class PreconditionerListTest(unittest.TestCase):
                 preconditioner_list.update_preconditioners(
                     masked_grad_list=masked_grad_list,
                     step=torch.tensor(step),
-                    # Only compute the new layerwise direction when the update_preconditioners() reach the last step.
+                    # Only update the complete preconditioner during the last call to update_preconditioners().
                     perform_amortized_computation=isinstance(
-                        preconditioner_list, ShampooPreconditionerList
+                        preconditioner_list,
+                        (
+                            ShampooPreconditionerList,
+                            EigenvalueCorrectedShampooPreconditionerList,
+                        ),
                     )
                     and step == len(masked_grad_lists),
                 )

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -20,6 +20,7 @@ from distributed_shampoo.utils import shampoo_preconditioner_list
 from distributed_shampoo.utils.shampoo_block_info import BlockInfo
 from distributed_shampoo.utils.shampoo_preconditioner_list import (
     AdagradPreconditionerList,
+    BaseShampooPreconditionerList,
     DequantizePreconditionersContext,
     EigenvalueCorrectedShampooPreconditionerList,
     PreconditionerList,
@@ -76,11 +77,7 @@ class PreconditionerListTest(unittest.TestCase):
                     step=torch.tensor(step),
                     # Only update the complete preconditioner during the last call to update_preconditioners().
                     perform_amortized_computation=isinstance(
-                        preconditioner_list,
-                        (
-                            ShampooPreconditionerList,
-                            EigenvalueCorrectedShampooPreconditionerList,
-                        ),
+                        preconditioner_list, BaseShampooPreconditionerList
                     )
                     and step == len(masked_grad_lists),
                 )


### PR DESCRIPTION
`EigenvalueCorrectedShampooPreconditionerList` has to be added to the `isinstance` check explicitly since it does not inherit from `ShampooPreconditionerList`. This increases code coverage since [this line](https://github.com/facebookresearch/optimizers/blob/main/distributed_shampoo/utils/shampoo_preconditioner_list.py#L1232-L1235) and [this line](https://github.com/facebookresearch/optimizers/blob/main/distributed_shampoo/utils/shampoo_preconditioner_list.py#L1245-L1249) are also covered.