### PR TITLE
Improve setuptools config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include distributed_shampoo *
+recursive-include tests *
+recursive-exclude * __pycache__/*

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Install `distributed_shampoo` with all dependencies:
 ```
 git clone git@github.com:facebookresearch/optimizers.git
 cd optimizers
-pip install -e .
+pip install .
 ```
+If you also want to try the [examples](./distributed_shampoo/examples/), replace the last line with `pip install ".[examples]"`.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "optimizers"
 version = "1.0.0"
 dependencies = [
     "torch>=2.2.0",
-    "torchvision>=0.15.0",
 ]
 requires-python = ">=3.10"
 authors = [
@@ -34,7 +33,12 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+examples = [
+  "torchvision>=0.15.0",
+]
+
 dev = [
+  "optimizers[examples]",
   "ruff",
   "usort",
   "mypy",
@@ -46,6 +50,7 @@ Repository = "https://github.com/facebookresearch/optimizers.git"
 "Bug Tracker" = "https://github.com/facebookresearch/optimizers/issues"
 
 [tool.setuptools]
+include-package-data = false
 py-modules = [
     "matrix_functions",
     "matrix_functions_types",
@@ -54,6 +59,7 @@ py-modules = [
 
 [tool.setuptools.packages.find]
 include = ["distributed_shampoo*"]
+exclude = ["*examples", "*tests"]
 
 [tool.usort]
 first_party_detection = false


### PR DESCRIPTION
Follow-up to #39.

This removes all `examples` and `tests` folders from the wheel, but keeps them in the sdist (by adding a `MANIFEST.in` file).