### PR TITLE
Add `QREigenvalueCorrectionConfig`

### DIFF
--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -36,6 +36,7 @@ from matrix_functions_types import (
     EigenConfig,
     EighEigenvalueCorrectionConfig,
     PreconditionerComputationConfig,
+    QREigenvalueCorrectionConfig,
 )
 from torch import nn
 from torchvision import datasets, transforms  # type: ignore[import-untyped]
@@ -73,6 +74,7 @@ class PreconditionerComputationType(enum.Enum):
     COUPLED_NEWTON_ROOT_INV = 1
     COUPLED_HIGHER_ORDER_ROOT_INV = 2
     EIGH_EIGENVALUE_CORRECTION = 3
+    QR_EIGENVALUE_CORRECTION = 4
 
 
 ###### ARGPARSER ######
@@ -556,6 +558,11 @@ def instantiate_preconditioner_computation_config(
         == PreconditionerComputationType.EIGH_EIGENVALUE_CORRECTION
     ):
         return EighEigenvalueCorrectionConfig()
+    elif (
+        preconditioner_computation_type
+        == PreconditionerComputationType.QR_EIGENVALUE_CORRECTION
+    ):
+        return QREigenvalueCorrectionConfig()
     else:
         raise ValueError(
             f"Invalid PreconditionerComputationType {preconditioner_computation_type}!"

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -1282,6 +1282,7 @@ class EigenvalueCorrectedShampooPreconditionerList(
                     try:
                         computed_eigenvectors = matrix_eigenvectors(
                             A=factor_matrix,
+                            eigenvectors_estimate=factor_matrix_eigenvectors,
                             eigenvector_computation_config=cast(
                                 EigenvalueCorrectionConfig,
                                 self._preconditioner_computation_config,

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -677,7 +677,8 @@ def _compute_orthogonal_iterations(
         A (Tensor): The symmetric input matrix.
         eigenvectors_estimate (Tensor): The current estimate of the eigenvectors of A.
         max_iterations (int): The maximum number of iterations to perform. (Default: 1)
-        tolerance (float): The tolerance for determining convergence. (Default: 1e-5)
+        tolerance (float): The tolerance for determining convergence in terms of the relative change of the eigenvectors estimate.
+            (Default: 1e-5)
 
     Returns:
         Tensor: The approximate eigenvectors of the input matrix A.
@@ -692,8 +693,7 @@ def _compute_orthogonal_iterations(
     error = torch.inf
     while iteration < max_iterations and error > tolerance:
         power_iteration = A @ Q
-        last_Q = Q
-        Q = torch.linalg.qr(power_iteration).Q
+        last_Q, Q = Q, torch.linalg.qr(power_iteration).Q
         iteration += 1
         error = last_Q.sub(Q).norm().div_(last_Q.norm())
 

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -695,7 +695,7 @@ def _compute_orthogonal_iterations(
         last_Q = Q
         Q = torch.linalg.qr(power_iteration).Q
         iteration += 1
-        error = last_Q.sub_(Q).norm().div_(last_Q.norm())
+        error = last_Q.sub(Q).norm().div_(last_Q.norm())
 
     # Ensure consistent ordering of estimated eigenvectors.
     estimated_eigenvalues = torch.einsum("ij, ik, kj -> j", Q, A, Q)

--- a/matrix_functions_types.py
+++ b/matrix_functions_types.py
@@ -109,4 +109,11 @@ DefaultEighEigenvalueCorrectionConfig = EighEigenvalueCorrectionConfig()
 
 @dataclass(kw_only=True)
 class QREigenvalueCorrectionConfig(EigenvalueCorrectionConfig):
-    """Configuration for one-step power iteration and subsequent QR decomposition used in eigenvalue-corrected Shampoo."""
+    """Configuration for orthogonal/simultaneous iterations (QR algorithm) used in eigenvalue-corrected Shampoo.
+
+    Args:
+        num_iterations (int): The number of iterations to perform. (Default: 1)
+
+    """
+
+    num_iterations: int = 1

--- a/matrix_functions_types.py
+++ b/matrix_functions_types.py
@@ -86,14 +86,14 @@ class CoupledHigherOrderConfig(RootInvConfig):
 
 @dataclass
 class EigenvalueCorrectionConfig(PreconditionerComputationConfig):
-    """Base dataclass for matrix eigenvector method configurations in Shampoo."""
+    """Base dataclass for matrix eigenvector method configurations in eigenvalue-corrected Shampoo."""
 
     ...
 
 
 @dataclass(kw_only=True)
 class EighEigenvalueCorrectionConfig(EigenvalueCorrectionConfig):
-    """Configuration for eigendecomposition method used in eigenvalue corrected Shampoo.
+    """Configuration for eigendecomposition method used in eigenvalue-corrected Shampoo.
 
     Args:
         retry_double_precision (bool): Whether to re-trying eigendecomposition with higher(double) precision if lower precision fails due
@@ -105,3 +105,8 @@ class EighEigenvalueCorrectionConfig(EigenvalueCorrectionConfig):
 
 
 DefaultEighEigenvalueCorrectionConfig = EighEigenvalueCorrectionConfig()
+
+
+@dataclass(kw_only=True)
+class QREigenvalueCorrectionConfig(EigenvalueCorrectionConfig):
+    """Configuration for one-step power iteration and subsequent QR decomposition used in eigenvalue-corrected Shampoo."""

--- a/matrix_functions_types.py
+++ b/matrix_functions_types.py
@@ -112,8 +112,10 @@ class QREigenvalueCorrectionConfig(EigenvalueCorrectionConfig):
     """Configuration for orthogonal/simultaneous iterations (QR algorithm) used in eigenvalue-corrected Shampoo.
 
     Args:
-        num_iterations (int): The number of iterations to perform. (Default: 1)
+        max_iterations (int): The maximum number of iterations to perform. (Default: 1)
+        tolerance (float): The tolerance for determining convergence. (Default: 1e-5)
 
     """
 
-    num_iterations: int = 1
+    max_iterations: int = 1
+    tolerance: float = 1e-5

--- a/matrix_functions_types.py
+++ b/matrix_functions_types.py
@@ -113,7 +113,8 @@ class QREigenvalueCorrectionConfig(EigenvalueCorrectionConfig):
 
     Args:
         max_iterations (int): The maximum number of iterations to perform. (Default: 1)
-        tolerance (float): The tolerance for determining convergence. (Default: 1e-5)
+        tolerance (float): The tolerance for determining convergence in terms of the relative change of the eigenvectors estimate.
+            (Default: 1e-5)
 
     """
 

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -863,6 +863,33 @@ class MatrixEigenvectorsTest(unittest.TestCase):
                     rtol=rtol,
                 )
         with self.subTest(
+            "Test with QREigenvalueCorrectionConfig with identity initialization."
+        ):
+            # Set `max_iterations` to large int to run until numerical tolerance is hit.
+            qr_config = QREigenvalueCorrectionConfig(max_iterations=10_000)
+            for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
+                estimated_eigenvectors = matrix_eigenvectors(
+                    A,
+                    eigenvectors_estimate=torch.eye(
+                        A.shape[0], dtype=A.dtype, device=A.device
+                    ),
+                    is_diagonal=False,
+                    eigenvector_computation_config=qr_config,
+                )
+                # Ensure that the signs of the eigenvectors are consistent.
+                for col in range(A.shape[1]):
+                    if (
+                        expected_eigenvectors[0, col] / estimated_eigenvectors[0, col]
+                        < 0
+                    ):
+                        estimated_eigenvectors[:, col] *= -1
+                torch.testing.assert_close(
+                    expected_eigenvectors,
+                    estimated_eigenvectors,
+                    atol=atol,
+                    rtol=rtol,
+                )
+        with self.subTest(
             "Test with QREigenvalueCorrectionConfig with exact initialization."
         ):
             # Set `max_iterations` to large int to run until numerical tolerance is hit.

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -35,6 +35,7 @@ from matrix_functions_types import (
     CoupledNewtonConfig,
     EigenConfig,
     EigenvalueCorrectionConfig,
+    QREigenvalueCorrectionConfig,
     RootInvConfig,
 )
 from torch import Tensor
@@ -841,6 +842,22 @@ class MatrixEigenvectorsTest(unittest.TestCase):
                     matrix_eigenvectors(
                         A,
                         is_diagonal=False,
+                    ),
+                    atol=atol,
+                    rtol=rtol,
+                )
+        with self.subTest(
+            "Test with QREigenvalueCorrectionConfig with zero initialization."
+        ):
+            qr_config = QREigenvalueCorrectionConfig()
+            for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
+                torch.testing.assert_close(
+                    expected_eigenvectors,
+                    matrix_eigenvectors(
+                        A,
+                        eigenvectors_estimate=torch.zeros_like(A),
+                        is_diagonal=False,
+                        eigenvector_computation_config=qr_config,
                     ),
                     atol=atol,
                     rtol=rtol,

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -865,8 +865,8 @@ class MatrixEigenvectorsTest(unittest.TestCase):
         with self.subTest(
             "Test with QREigenvalueCorrectionConfig with exact initialization."
         ):
-            # Setting `num_iterations=2` is necessary to preserve the solution.
-            qr_config = QREigenvalueCorrectionConfig(num_iterations=2)
+            # Set `max_iterations` to large int to run until numerical tolerance is hit.
+            qr_config = QREigenvalueCorrectionConfig(max_iterations=10_000)
             for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
                 eigenvectors = matrix_eigenvectors(A)  # Eigendecomposition.
                 estimated_eigenvectors = matrix_eigenvectors(

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -862,6 +862,32 @@ class MatrixEigenvectorsTest(unittest.TestCase):
                     atol=atol,
                     rtol=rtol,
                 )
+        with self.subTest(
+            "Test with QREigenvalueCorrectionConfig with exact initialization."
+        ):
+            # Setting `num_iterations=2` is necessary to preserve the solution.
+            qr_config = QREigenvalueCorrectionConfig(num_iterations=2)
+            for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
+                eigenvectors = matrix_eigenvectors(A)  # Eigendecomposition.
+                estimated_eigenvectors = matrix_eigenvectors(
+                    A,
+                    eigenvectors_estimate=eigenvectors,
+                    is_diagonal=False,
+                    eigenvector_computation_config=qr_config,
+                )
+                # Ensure that the signs of the eigenvectors are consistent.
+                for col in range(A.shape[1]):
+                    if (
+                        expected_eigenvectors[0, col] / estimated_eigenvectors[0, col]
+                        < 0
+                    ):
+                        estimated_eigenvectors[:, col] *= -1
+                torch.testing.assert_close(
+                    expected_eigenvectors,
+                    estimated_eigenvectors,
+                    atol=atol,
+                    rtol=rtol,
+                )
 
     def test_invalid_eigenvalue_correction_config(
         self,

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -836,7 +836,9 @@ class MatrixEigenvectorsTest(unittest.TestCase):
                 rtol=rtol,
             )
         with self.subTest("Test with EIGEN."):
-            for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
+            for A, expected_eigenvectors in zip(
+                A_list, expected_eigenvectors_list, strict=True
+            ):
                 torch.testing.assert_close(
                     expected_eigenvectors,
                     matrix_eigenvectors(
@@ -846,75 +848,42 @@ class MatrixEigenvectorsTest(unittest.TestCase):
                     atol=atol,
                     rtol=rtol,
                 )
-        with self.subTest(
-            "Test with QREigenvalueCorrectionConfig with zero initialization."
-        ):
-            qr_config = QREigenvalueCorrectionConfig()
-            for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
-                torch.testing.assert_close(
-                    expected_eigenvectors,
-                    matrix_eigenvectors(
+
+        # Tests for `QREigenvalueCorrectionConfig`.
+        initialization_strategies = {
+            "zero": lambda A: torch.zeros_like(A),
+            "identity": lambda A: torch.eye(A.shape[0], dtype=A.dtype, device=A.device),
+            "exact": lambda A: matrix_eigenvectors(A),  # Eigendecomposition.
+        }
+        for name, initialization_fn in initialization_strategies.items():
+            with self.subTest(
+                f"Test with QREigenvalueCorrectionConfig with {name} initialization."
+            ):
+                # Set `max_iterations` to large int to run until numerical tolerance.
+                qr_config = QREigenvalueCorrectionConfig(max_iterations=10_000)
+                for A, expected_eigenvectors in zip(
+                    A_list, expected_eigenvectors_list, strict=True
+                ):
+                    estimated_eigenvectors = matrix_eigenvectors(
                         A,
-                        eigenvectors_estimate=torch.zeros_like(A),
+                        eigenvectors_estimate=initialization_fn(A),
                         is_diagonal=False,
                         eigenvector_computation_config=qr_config,
-                    ),
-                    atol=atol,
-                    rtol=rtol,
-                )
-        with self.subTest(
-            "Test with QREigenvalueCorrectionConfig with identity initialization."
-        ):
-            # Set `max_iterations` to large int to run until numerical tolerance is hit.
-            qr_config = QREigenvalueCorrectionConfig(max_iterations=10_000)
-            for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
-                estimated_eigenvectors = matrix_eigenvectors(
-                    A,
-                    eigenvectors_estimate=torch.eye(
-                        A.shape[0], dtype=A.dtype, device=A.device
-                    ),
-                    is_diagonal=False,
-                    eigenvector_computation_config=qr_config,
-                )
-                # Ensure that the signs of the eigenvectors are consistent.
-                for col in range(A.shape[1]):
-                    if (
-                        expected_eigenvectors[0, col] / estimated_eigenvectors[0, col]
-                        < 0
-                    ):
-                        estimated_eigenvectors[:, col] *= -1
-                torch.testing.assert_close(
-                    expected_eigenvectors,
-                    estimated_eigenvectors,
-                    atol=atol,
-                    rtol=rtol,
-                )
-        with self.subTest(
-            "Test with QREigenvalueCorrectionConfig with exact initialization."
-        ):
-            # Set `max_iterations` to large int to run until numerical tolerance is hit.
-            qr_config = QREigenvalueCorrectionConfig(max_iterations=10_000)
-            for A, expected_eigenvectors in zip(A_list, expected_eigenvectors_list):
-                eigenvectors = matrix_eigenvectors(A)  # Eigendecomposition.
-                estimated_eigenvectors = matrix_eigenvectors(
-                    A,
-                    eigenvectors_estimate=eigenvectors,
-                    is_diagonal=False,
-                    eigenvector_computation_config=qr_config,
-                )
-                # Ensure that the signs of the eigenvectors are consistent.
-                for col in range(A.shape[1]):
-                    if (
-                        expected_eigenvectors[0, col] / estimated_eigenvectors[0, col]
-                        < 0
-                    ):
-                        estimated_eigenvectors[:, col] *= -1
-                torch.testing.assert_close(
-                    expected_eigenvectors,
-                    estimated_eigenvectors,
-                    atol=atol,
-                    rtol=rtol,
-                )
+                    )
+                    # Ensure that the signs of the eigenvectors are consistent.
+                    for col in range(A.shape[1]):
+                        if (
+                            expected_eigenvectors[0, col]
+                            / estimated_eigenvectors[0, col]
+                            < 0
+                        ):
+                            estimated_eigenvectors[:, col] *= -1
+                    torch.testing.assert_close(
+                        expected_eigenvectors,
+                        estimated_eigenvectors,
+                        atol=atol,
+                        rtol=rtol,
+                    )
 
     def test_invalid_eigenvalue_correction_config(
         self,


### PR DESCRIPTION
Adds `QREigenvalueCorrectionConfig` to approximately compute eigenvectors with orthogonal/simultaneous iterations (the QR algorithm). This has been used for the same purpose in the [SOAP paper](https://arxiv.org/abs/2409.11321).