### PR TITLE
Avoid using local modules in some unittests

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,8 +9,8 @@ type-check:
 	@mypy .
 
 test:
-	@python3 -m unittest discover -s tests/ -p "*_test.py"
-	@python3 -m unittest discover -s distributed_shampoo/tests/ -p "*_test.py"
+	@python3 -I -m unittest discover -s tests/ -p "*_test.py"
+	@python3 -I -m unittest discover -s distributed_shampoo/tests/ -p "*_test.py"
 	@python3 -m unittest discover -s distributed_shampoo/utils/tests/ -p "*_test.py"
 	@python3 -m unittest discover -s distributed_shampoo/gpu_tests/ -p "*_test.py"
 	@python3 -m unittest distributed_shampoo/utils/gpu_tests/shampoo_dist_utils_test.py

--- a/makefile
+++ b/makefile
@@ -12,6 +12,7 @@ test:
     # We add the `-I` flag to only use the installed package and not use local modules.
     # Note that we cannot add it to all tests because of the implemented import logic.
     # See PR #49 for more details.
+    # TODO: Find better solution.
 	@python3 -I -m unittest discover -s tests/ -p "*_test.py"
 	@python3 -I -m unittest discover -s distributed_shampoo/tests/ -p "*_test.py"
 	@python3 -m unittest discover -s distributed_shampoo/utils/tests/ -p "*_test.py"

--- a/makefile
+++ b/makefile
@@ -9,6 +9,9 @@ type-check:
 	@mypy .
 
 test:
+    # We add the `-I` flag to only use the installed package and not use local modules.
+    # Note that we cannot add it to all tests because of the implemented import logic.
+    # See PR #49 for more details.
 	@python3 -I -m unittest discover -s tests/ -p "*_test.py"
 	@python3 -I -m unittest discover -s distributed_shampoo/tests/ -p "*_test.py"
 	@python3 -m unittest discover -s distributed_shampoo/utils/tests/ -p "*_test.py"


### PR DESCRIPTION
To avoid installation issues like #46, I added the Python `-I` flag when running two of the unittests.

Note that the unittests for which I didn't add this flag import from the `distributed_shampoo.tests` directory that is not installed as part of the package, so trying to run these tests with the `-I` flag will lead to an import error.