### PR TITLE
Extend `AbstractDataclass` for multiple inheritance

### DIFF
--- a/commons.py
+++ b/commons.py
@@ -14,6 +14,6 @@ from typing import Any
 @dataclass
 class AbstractDataclass:
     def __new__(cls, *args: Any, **kwargs: Any) -> "AbstractDataclass":
-        if cls == AbstractDataclass or cls.__bases__[0] == AbstractDataclass:
+        if cls == AbstractDataclass or AbstractDataclass in cls.__bases__:
             raise TypeError(f"Cannot instantiate abstract class: {cls.__name__}.")
         return super().__new__(cls)

--- a/matrix_functions_types.py
+++ b/matrix_functions_types.py
@@ -18,7 +18,7 @@ class PreconditionerComputationConfig(AbstractDataclass):
 
 
 @dataclass
-class RootInvConfig(PreconditionerComputationConfig):
+class RootInvConfig(PreconditionerComputationConfig, AbstractDataclass):
     """Base dataclass for matrix root inverse method configurations in Shampoo."""
 
 
@@ -81,7 +81,7 @@ class CoupledHigherOrderConfig(RootInvConfig):
 
 
 @dataclass
-class EigenvalueCorrectionConfig(PreconditionerComputationConfig):
+class EigenvalueCorrectionConfig(PreconditionerComputationConfig, AbstractDataclass):
     """Base dataclass for matrix eigenvector method configurations in eigenvalue-corrected Shampoo."""
 
 

--- a/tests/commons_test.py
+++ b/tests/commons_test.py
@@ -20,9 +20,20 @@ class DummyOptimizerConfig(AbstractDataclass):
     """Dummy abstract dataclass for testing. Instantiation should fail."""
 
 
+@dataclass
+class DummyOptimizerChildConfig(DummyOptimizerConfig, AbstractDataclass):
+    """Dummy abstract dataclass inheriting from other abstract dataclass for testing.
+    Instantiation should fail.
+    """
+
+
 class InvalidAbstractDataclassInitTest(unittest.TestCase):
     def test_invalid_init(self) -> None:
-        for abstract_cls in (AbstractDataclass, DummyOptimizerConfig):
+        for abstract_cls in (
+            AbstractDataclass,
+            DummyOptimizerConfig,
+            DummyOptimizerChildConfig,
+        ):
             with self.subTest(abstract_cls=abstract_cls), self.assertRaisesRegex(
                 TypeError,
                 re.escape(

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -12,6 +12,7 @@ import re
 import unittest
 import unittest.mock as mock
 from collections.abc import Callable
+from dataclasses import dataclass
 from fractions import Fraction
 from functools import partial
 from types import ModuleType
@@ -39,6 +40,11 @@ from matrix_functions_types import (
     RootInvConfig,
 )
 from torch import Tensor
+
+
+@dataclass
+class InvalidRootInvConfig:
+    """Dummy dataclass for testing."""
 
 
 class CheckDiagonalTest(unittest.TestCase):
@@ -290,13 +296,13 @@ class MatrixInverseRootTest(unittest.TestCase):
         with self.assertRaisesRegex(
             NotImplementedError,
             re.escape(
-                "Root inverse config is not implemented! Specified root inverse config is root_inv_config=RootInvConfig()."
+                "Root inverse config is not implemented! Specified root inverse config is root_inv_config=InvalidRootInvConfig()."
             ),
         ):
             matrix_inverse_root(
                 A=A,
                 root=root,
-                root_inv_config=RootInvConfig(),
+                root_inv_config=InvalidRootInvConfig(),
                 is_diagonal=False,
             )
 

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -43,7 +43,7 @@ from torch import Tensor
 
 
 @dataclass
-class InvalidRootInvConfig:
+class InvalidRootInvConfig(RootInvConfig):
     """Dummy dataclass for testing."""
 
 


### PR DESCRIPTION
To make sure base classes can't be instantiated I extended `AbstractDataclass` to allow for using it via multiple inheritance. I applied this to `RootInvConfig` and `EigenvalueCorrectionConfig`.