### PR TITLE
Simplify importing from `distributed_shampoo` package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ We actively welcome your pull requests for existing optimizers.
 5. Make sure your code lints. You can use `make lint` and `make format` to automatically lint and format the code where possible. Use `make type-check` for type checking.
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
+> [!NOTE]
+> If you add a new class or function that a user of the package might want to interact with directly, make sure to add it [here](distributed_shampoo/__init__.py).
+
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need
 to do this once to work on any of Meta's open source projects.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ If you also want to try the [examples](./distributed_shampoo/examples/), replace
 After installation, basic usage looks like:
 ```
 import torch
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import AdamGraftingConfig
+from distributed_shampoo import AdamGraftingConfig, DistributedShampoo
 
 model = ...  # Instantiate model
 

--- a/distributed_shampoo/README.md
+++ b/distributed_shampoo/README.md
@@ -85,8 +85,7 @@ optimizer = SGD(
 we would instead use:
 ```
 import torch
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import SGDGraftingConfig
+from distributed_shampoo import DistributedShampoo, SGDGraftingConfig
 
 model = instantiate_model()
 
@@ -124,8 +123,7 @@ optimizer = Adam(
 we would instead use:
 ```
 import torch
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import AdamGraftingConfig
+from distributed_shampoo import AdamGraftingConfig, DistributedShampoo
 
 model = instantiate_model()
 
@@ -164,8 +162,7 @@ optimizer = Adagrad(
 we would instead use:
 ```
 import torch
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import AdaGradGraftingConfig
+from distributed_shampoo import AdaGradGraftingConfig, DistributedShampoo
 
 model = instantiate_model()
 
@@ -204,8 +201,7 @@ optimizer = AdamW(
 we would instead use:
 ```
 import torch
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import AdamGraftingConfig
+from distributed_shampoo import AdamGraftingConfig, DistributedShampoo
 
 model = instantiate_model()
 
@@ -245,8 +241,12 @@ import os
 import torch
 import torch.distributed as dist
 
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import AdamGraftingConfig, CommunicationDType, DDPShampooConfig
+from distributed_shampoo import (
+    AdamGraftingConfig,
+    CommunicationDType,
+    DDPShampooConfig,
+    DistributedShampoo,
+)
 from torch import nn
 
 LOCAL_RANK = int(os.environ["LOCAL_RANK"])
@@ -301,9 +301,12 @@ import torch
 import torch.distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.shampoo_types import AdamGraftingConfig, FSDPShampooConfig
-from distributed_shampoo.utils.shampoo_fsdp_utils import compile_fsdp_parameter_metadata
+from distributed_shampoo import (
+    AdamGraftingConfig,
+    compile_fsdp_parameter_metadata,
+    DistributedShampoo,
+    FSDPShampooConfig,
+)
 
 LOCAL_RANK = int(os.environ["LOCAL_RANK"])
 WORLD_RANK = int(os.environ["RANK"])

--- a/distributed_shampoo/__init__.py
+++ b/distributed_shampoo/__init__.py
@@ -56,7 +56,7 @@ __all__ = [
     "CoupledHigherOrderConfig",
     "EigenvalueCorrectionConfig",  # Abstract base class (based on `PreconditionerComputationConfig`).
     "EighEigenvalueCorrectionConfig",
-    "DefaultEighEigenvalueCorrectionConfig",  # Default `EighEigenvalueCorrectionConfig`.
+    "DefaultEighEigenvalueCorrectionConfig",  # Default `EigenvalueCorrectionConfig`.
     "QREigenvalueCorrectionConfig",
     # Other utilities.
     "compile_fsdp_parameter_metadata",  # For `FSDPShampooConfig` and `HSDPShampooConfig`.

--- a/distributed_shampoo/__init__.py
+++ b/distributed_shampoo/__init__.py
@@ -1,0 +1,64 @@
+from distributed_shampoo.distributed_shampoo import DistributedShampoo
+from distributed_shampoo.shampoo_types import (
+    AdaGradGraftingConfig,
+    AdamGraftingConfig,
+    CommunicationDType,
+    DDPShampooConfig,
+    DistributedConfig,
+    FSDPShampooConfig,
+    FullyShardShampooConfig,
+    GraftingConfig,
+    HSDPShampooConfig,
+    PrecisionConfig,
+    RMSpropGraftingConfig,
+    SGDGraftingConfig,
+    ShampooPT2CompileConfig,
+)
+from distributed_shampoo.utils.shampoo_fsdp_utils import compile_fsdp_parameter_metadata
+from matrix_functions_types import (
+    CoupledHigherOrderConfig,
+    CoupledNewtonConfig,
+    DefaultEigenConfig,
+    DefaultEighEigenvalueCorrectionConfig,
+    EigenConfig,
+    EigenvalueCorrectionConfig,
+    EighEigenvalueCorrectionConfig,
+    PreconditionerComputationConfig,
+    QREigenvalueCorrectionConfig,
+    RootInvConfig,
+)
+
+
+__all__ = [
+    "DistributedShampoo",
+    # `grafting_config` options.
+    "GraftingConfig",  # Abstract base class.
+    "SGDGraftingConfig",
+    "AdaGradGraftingConfig",
+    "RMSpropGraftingConfig",
+    "AdamGraftingConfig",
+    # PT2 compile.
+    "ShampooPT2CompileConfig",
+    # `distributed_config` options.
+    "DistributedConfig",  # Abstract base class.
+    "DDPShampooConfig",
+    "FSDPShampooConfig",
+    "FullyShardShampooConfig",
+    "HSDPShampooConfig",
+    # `precision_config`.
+    "PrecisionConfig",
+    # `preconditioner_computation_config` options.
+    "PreconditionerComputationConfig",  # Abstract base class.
+    "RootInvConfig",  # Abstract base class (based on `PreconditionerComputationConfig`).
+    "EigenConfig",
+    "DefaultEigenConfig",  # Default `RootInvConfig`.
+    "CoupledNewtonConfig",
+    "CoupledHigherOrderConfig",
+    "EigenvalueCorrectionConfig",  # Abstract base class (based on `PreconditionerComputationConfig`).
+    "EighEigenvalueCorrectionConfig",
+    "DefaultEighEigenvalueCorrectionConfig",  # Default `EighEigenvalueCorrectionConfig`.
+    "QREigenvalueCorrectionConfig",
+    # Other utilities.
+    "compile_fsdp_parameter_metadata",  # For `FSDPShampooConfig` and `HSDPShampooConfig`.
+    "CommunicationDType",  # For `DDPShampooConfig` and `HSDPShampooConfig`.
+]

--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -13,7 +13,7 @@ import os
 import torch.distributed as dist
 import torch.distributed.checkpoint as dist_checkpoint
 
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
+from distributed_shampoo import DDPShampooConfig, DistributedShampoo, PrecisionConfig
 from distributed_shampoo.examples.trainer_utils import (
     get_data_loader_and_sampler,
     get_model_and_loss_fn,
@@ -23,7 +23,6 @@ from distributed_shampoo.examples.trainer_utils import (
     setup_distribution,
     train_model,
 )
-from distributed_shampoo.shampoo_types import DDPShampooConfig, PrecisionConfig
 from torch import nn
 
 logging.basicConfig(

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -11,6 +11,7 @@ import logging
 import os
 
 import torch
+from distributed_shampoo import PrecisionConfig
 
 from distributed_shampoo.examples.trainer_utils import (
     get_data_loader_and_sampler,
@@ -20,7 +21,6 @@ from distributed_shampoo.examples.trainer_utils import (
     Parser,
     set_seed,
 )
-from distributed_shampoo.shampoo_types import PrecisionConfig
 from torch import nn
 
 logging.basicConfig(

--- a/distributed_shampoo/examples/fsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/fsdp_cifar10_example.py
@@ -11,6 +11,12 @@ import logging
 import os
 
 import torch.distributed as dist
+
+from distributed_shampoo import (
+    compile_fsdp_parameter_metadata,
+    FSDPShampooConfig,
+    PrecisionConfig,
+)
 from distributed_shampoo.examples.trainer_utils import (
     get_data_loader_and_sampler,
     get_model_and_loss_fn,
@@ -20,9 +26,6 @@ from distributed_shampoo.examples.trainer_utils import (
     setup_distribution,
     train_model,
 )
-
-from distributed_shampoo.shampoo_types import FSDPShampooConfig, PrecisionConfig
-from distributed_shampoo.utils.shampoo_fsdp_utils import compile_fsdp_parameter_metadata
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 logging.basicConfig(

--- a/distributed_shampoo/examples/fully_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/fully_shard_cifar10_example.py
@@ -14,7 +14,11 @@ import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dist_checkpoint
 
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
+from distributed_shampoo import (
+    DistributedShampoo,
+    FullyShardShampooConfig,
+    PrecisionConfig,
+)
 from distributed_shampoo.examples.trainer_utils import (
     get_data_loader_and_sampler,
     get_model_and_loss_fn,
@@ -24,8 +28,6 @@ from distributed_shampoo.examples.trainer_utils import (
     set_seed,
     setup_distribution,
 )
-
-from distributed_shampoo.shampoo_types import FullyShardShampooConfig, PrecisionConfig
 
 from torch import nn
 from torch.distributed._composable.fsdp import fully_shard

--- a/distributed_shampoo/examples/hsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/hsdp_cifar10_example.py
@@ -12,6 +12,12 @@ import os
 
 import torch.distributed as dist
 
+from distributed_shampoo import (
+    compile_fsdp_parameter_metadata,
+    HSDPShampooConfig,
+    PrecisionConfig,
+)
+
 from distributed_shampoo.examples.trainer_utils import (
     get_data_loader_and_sampler,
     get_model_and_loss_fn,
@@ -21,9 +27,6 @@ from distributed_shampoo.examples.trainer_utils import (
     setup_distribution,
     train_model,
 )
-
-from distributed_shampoo.shampoo_types import HSDPShampooConfig, PrecisionConfig
-from distributed_shampoo.utils.shampoo_fsdp_utils import compile_fsdp_parameter_metadata
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
 

--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -18,26 +18,25 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
-from distributed_shampoo.distributed_shampoo import DistributedShampoo
-from distributed_shampoo.examples.convnet import ConvNet
-from distributed_shampoo.shampoo_types import (
+from distributed_shampoo import (
     AdaGradGraftingConfig,
     AdamGraftingConfig,
     CommunicationDType,
+    CoupledHigherOrderConfig,
+    CoupledNewtonConfig,
     DistributedConfig,
+    DistributedShampoo,
+    EigenConfig,
+    EighEigenvalueCorrectionConfig,
     GraftingConfig,
     PrecisionConfig,
+    PreconditionerComputationConfig,
+    QREigenvalueCorrectionConfig,
     RMSpropGraftingConfig,
     SGDGraftingConfig,
 )
-from matrix_functions_types import (
-    CoupledHigherOrderConfig,
-    CoupledNewtonConfig,
-    EigenConfig,
-    EighEigenvalueCorrectionConfig,
-    PreconditionerComputationConfig,
-    QREigenvalueCorrectionConfig,
-)
+from distributed_shampoo.examples.convnet import ConvNet
+
 from torch import nn
 from torchvision import datasets, transforms  # type: ignore[import-untyped]
 


### PR DESCRIPTION
I added all user facing classes and functions to `distributed_shampoo/__init__.py` to simplify the API for users. I also adjusted all examples to import from `distributed_shampoo` directly.