### PR TITLE
Add workflow that runs examples

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -35,15 +35,3 @@ jobs:
           run: |
             source .venv/bin/activate
             torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.ddp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024
-        - name: Run FSDP example on GPU.
-          run: |
-            source .venv/bin/activate
-            torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.fsdp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024
-        - name: Run HSDP example on GPU.
-          run: |
-            source .venv/bin/activate
-            torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.hsdp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024
-        - name: Run fully-sharded example on GPU.
-          run: |
-            source .venv/bin/activate
-            torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.fully_shard_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -3,7 +3,7 @@ name: examples
 on: [pull_request]
 
 jobs:
-  gpu-tests:
+  examples:
     name: "Python 3.10"
     runs-on: 4-core-ubuntu-gpu-t4
     steps:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -31,3 +31,19 @@ jobs:
           run: |
             source .venv/bin/activate
             CUDA_VISIBLE_DEVICES="" torchrun --standalone --nnodes=1 --nproc_per_node=2 -m distributed_shampoo.examples.ddp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 15 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024 --backend gloo
+        - name: Run DDP example on GPU.
+          run: |
+            source .venv/bin/activate
+            torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.ddp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024
+        - name: Run FSDP example on GPU.
+          run: |
+            source .venv/bin/activate
+            torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.fsdp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024
+        - name: Run HSDP example on GPU.
+          run: |
+            source .venv/bin/activate
+            torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.hsdp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024
+        - name: Run fully-sharded example on GPU.
+          run: |
+            source .venv/bin/activate
+            torchrun --standalone --nnodes=1 --nproc_per_node=1 -m distributed_shampoo.examples.fully_shard_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,6 +1,6 @@
 name: examples
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   examples:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,6 +1,6 @@
 name: examples
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   gpu-tests:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,0 +1,33 @@
+name: examples
+
+on: [pull_request]
+
+jobs:
+  gpu-tests:
+    name: "Python 3.10"
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+        - uses: actions/checkout@v4
+        - name: Set up and update uv.
+          run: |
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            source $HOME/.local/bin/env
+            uv self update
+        - name: Install Python.
+          run: uv python install 3.10
+        - name: Create venv and install the package.
+          run: |
+            uv venv && source .venv/bin/activate
+            uv pip install ".[examples]"
+        - name: Run default example on CPU.
+          run: |
+            source .venv/bin/activate
+            CUDA_VISIBLE_DEVICES="" python -m distributed_shampoo.examples.default_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --batch-size 1024
+        - name: Run default example on GPU.
+          run: |
+            source .venv/bin/activate
+            python -m distributed_shampoo.examples.default_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 30 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --batch-size 1024
+        - name: Run DDP example on CPU.
+          run: |
+            source .venv/bin/activate
+            CUDA_VISIBLE_DEVICES="" torchrun --standalone --nnodes=1 --nproc_per_node=2 -m distributed_shampoo.examples.ddp_cifar10_example --optimizer-type DISTRIBUTED_SHAMPOO --precondition-frequency 15 --grafting-type ADAM --use-bias-correction --use-decoupled-weight-decay --use-merge-dims --epochs 1 --local-batch-size 1024 --backend gloo

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,6 +1,6 @@
 name: examples
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   gpu-tests:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![format-ruff](https://github.com/facebookresearch/optimizers/actions/workflows/format-ruff.yaml/badge.svg)
 ![format-usort](https://github.com/facebookresearch/optimizers/actions/workflows/format-usort.yaml/badge.svg)
 ![type-check-mypy](https://github.com/facebookresearch/optimizers/actions/workflows/type-check-mypy.yaml/badge.svg)
+![examples](https://github.com/facebookresearch/optimizers/actions/workflows/examples.yaml/badge.svg)
 
 *Copyright (c) Meta Platforms, Inc. and affiliates.
 All rights reserved.*

--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     Uses torch.distributed to launch distributed training run.
 
     Requirements:
-        - Python 3.8 or above
+        - Python 3.10 or above
         - PyTorch / TorchVision
 
     To run this training script with a single node, one can run from the optimizers directory:
@@ -82,9 +82,12 @@ if __name__ == "__main__":
 
     # instantiate model and loss function
     model, loss_function = get_model_and_loss_fn(device)
-    model = nn.parallel.DistributedDataParallel(
-        model, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK
+    device_kwargs = (
+        {"device_ids": [LOCAL_RANK], "output_device": LOCAL_RANK}
+        if args.backend == "nccl"
+        else {}
     )
+    model = nn.parallel.DistributedDataParallel(model, **device_kwargs)  # type: ignore
 
     # instantiate data loader
     data_loader, sampler = get_data_loader_and_sampler(

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     Trains a simple convolutional network with a single GPU.
 
     Requirements:
-        - Python 3.8 or above
+        - Python 3.10 or above
         - PyTorch / TorchVision
 
     To run this simple training script, one can run from the optimizers directory:

--- a/distributed_shampoo/examples/fsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/fsdp_cifar10_example.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     Uses torch.distributed to launch distributed training run.
 
     Requirements:
-        - Python 3.8 or above
+        - Python 3.10 or above
         - PyTorch / TorchVision
 
     To run this training script with a single node, one can run from the optimizers directory:

--- a/distributed_shampoo/examples/fully_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/fully_shard_cifar10_example.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     Uses torch.distributed to launch distributed training run.
 
     Requirements:
-        - Python 3.8 or above
+        - Python 3.10 or above
         - PyTorch / TorchVision
 
     To run this training script with a single node, one can run from the optimizers directory:

--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -616,13 +616,15 @@ def setup_distribution(
         rank=world_rank,
         world_size=world_size,
     )
-    device = torch.device("cuda:{}".format(local_rank))
+    use_cuda = torch.cuda.is_available()
+    device = torch.device("cuda" if use_cuda else "cpu", local_rank)
 
-    # Necessary to ensure DTensor's local tensors are instantiated
-    # on the correct device.
-    #
-    # TODO: DTensor zeros instantiation needs to be fixed.
-    torch.cuda.set_device(local_rank)
+    if use_cuda:
+        # Necessary to ensure DTensor's local tensors are instantiated
+        # on the correct device.
+        #
+        # TODO: DTensor zeros instantiation needs to be fixed.
+        torch.cuda.set_device(local_rank)
 
     return device
 


### PR DESCRIPTION
Added a workflow that runs the default and DDP example on CPU and GPU for one epoch. ~This workflow only runs when a PR is created and not on every push, in contrast to all other workloads.~ *Edit: The workflow runs on `push` and `pull_request`, like all other workflows.*

I think the FSDP, HSDP, and fully shard examples cannot be run on a single GPU since the PyTorch source code sets `sharding_strategy=NO_SHARD` when the world size is 1. Because of this the parameters are not flattened, which will lead to an error [here](https://github.com/facebookresearch/optimizers/blob/main/distributed_shampoo/utils/shampoo_fsdp_distributor.py#L358-L361).

In the future it would be great to make this a proper regression test and 1) check that the loss value after one epoch stays the same and 2) that the update step time stays the same (both within some threshold).