### PR TITLE
Deactivate ruff formatting check from workflow

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -18,10 +18,11 @@ jobs:
       - name: Run usort check.
         run: |
           usort check .
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
-        with:
-          args: "format --check"
+  # TODO: make formatting with ruff consistent across internal and open-source code.
+  # ruff:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: astral-sh/ruff-action@v1
+  #       with:
+  #         args: "format --check"


### PR DESCRIPTION
Until we make ensure consistent formatting with ruff across internal and open-source code.