### PR TITLE
Refactor Distributors to make it acutally do its jobs

### DIFF
--- a/distributed_shampoo/utils/shampoo_fully_shard_distributor.py
+++ b/distributed_shampoo/utils/shampoo_fully_shard_distributor.py
@@ -65,10 +65,10 @@ class FullyShardDistributor(Distributor):
         return (param_index, f"rank_{rank}-block_{block_index}")
 
     @torch.no_grad()
-    def _construct_global_block_info_list(
+    def _construct_local_block_info_list(
         self,
-    ) -> None:
-        """Construct global block info list from param_group and num_blocks_within_param."""
+    ) -> tuple[BlockInfo, ...]:
+        """Construct local block info list from param_group and num_blocks_within_param."""
         rank = dist.get_rank()
 
         # Call `super()` instead of `self` as a performance optimization.
@@ -77,7 +77,7 @@ class FullyShardDistributor(Distributor):
             lambda p: p.to_local().numel() > 0,  # type: ignore[arg-type]
             super()._get_params_or_grads(),
         )
-        self._global_block_info_list = tuple(
+        return tuple(
             BlockInfo(
                 param=param,
                 composable_block_ids=self._construct_composable_block_ids(

--- a/distributed_shampoo/utils/shampoo_hsdp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hsdp_distributor.py
@@ -200,12 +200,13 @@ class HSDPDistributor(DistributorInterface):
             )
         )
 
-        self._construct_global_block_info_list(buffer_size_ranks)
-
+        global_block_info_list = self._construct_global_block_info_list(
+            buffer_size_ranks
+        )
         # Initialize selectors and local blocked (masked) parameters.
         self._distributor_selector: tuple[bool, ...] = tuple(
             block_info.group_source_rank == comms_group_rank
-            for block_info in self._global_block_info_list
+            for block_info in global_block_info_list
         )
         self._local_blocked_params: tuple[Tensor, ...] = compress_list(
             self._global_blocked_params, self._distributor_selector
@@ -215,6 +216,9 @@ class HSDPDistributor(DistributorInterface):
         )
         self._local_grad_selector: tuple[bool, ...] = (True,) * len(
             self._local_blocked_params
+        )
+        self._local_block_info_list: tuple[DDPBlockInfo, ...] = compress_list(
+            global_block_info_list, self._distributor_selector
         )
 
         self._construct_distributed_buffers(
@@ -369,14 +373,15 @@ class HSDPDistributor(DistributorInterface):
         """
         return (param_index, f"rank_{rank}-block_{block_index}")
 
+    @torch.no_grad()
     def _construct_global_block_info_list(
         self, buffer_size_ranks: tuple[tuple[int, int], ...]
-    ) -> None:
+    ) -> tuple[DDPBlockInfo, ...]:
         """Construct global block info list from param_group and num_blocks_within_param."""
         # Note that for HSDP, we want to get the rank within each sharded group for the block id.
         # When using a device mesh, 0 corresponds to the replicated group and 1 corresponds to the sharded group.
         sharded_group_rank = self._hsdp_device_mesh.get_local_rank(1)
-        self._global_block_info_list: tuple[DDPBlockInfo, ...] = tuple(
+        return tuple(
             DDPBlockInfo(
                 param=param,
                 composable_block_ids=self._construct_composable_block_ids(
@@ -575,7 +580,7 @@ class HSDPDistributor(DistributorInterface):
         self._global_dist_buffer = torch.zeros(
             total_buffer_size,
             dtype=torch.int8,
-            device=self._global_block_info_list[0].param.device,
+            device=self._global_blocked_params[0].device,
         )
         local_dist_buffers = torch.split(self._global_dist_buffer, max_buffer_size_sum)
         splitted_local_dist_buffers = HSDPDistributor._split_local_dist_buffers(

--- a/distributed_shampoo/utils/tests/shampoo_distributor_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_distributor_test.py
@@ -90,14 +90,6 @@ class DistributorTest(DistributorInterfaceTest):
             actual_masked_blocked_params, expected_masked_blocked_params
         )
 
-    def test_distributor_selector(self) -> None:
-        # Two blocks from the linear layer, and one block from the bias layer.
-        expected_distributor_selector = (True, True, True)
-        self.assertEqual(
-            self._distributor.distributor_selector,
-            expected_distributor_selector,
-        )
-
     def test_local_grad_selector(self) -> None:
         # Explicitly disable the gradient of the bias layer and call merge_and_block_gradients()
         # to update the local gradient selector for the bias layer (i.e., 3rd block).
@@ -109,17 +101,6 @@ class DistributorTest(DistributorInterfaceTest):
         self.assertEqual(
             self._distributor.local_grad_selector,
             expected_local_grad_selector,
-        )
-
-    def test_global_blocked_params(self) -> None:
-        expected_global_params = (
-            torch.zeros(5, 5, dtype=torch.float),
-            torch.zeros(5, 5, dtype=torch.float),
-            torch.zeros(5, dtype=torch.float),
-        )
-        torch.testing.assert_close(
-            self._distributor.global_blocked_params,
-            expected_global_params,
         )
 
     def test_local_blocked_params(self) -> None:
@@ -135,8 +116,8 @@ class DistributorTest(DistributorInterfaceTest):
             expected_local_params,
         )
 
-    def test_global_block_info_list(self) -> None:
-        expected_global_block_info_list = (
+    def test_local_block_info_list(self) -> None:
+        expected_local_block_info_list = (
             BlockInfo(
                 param=self._model.linear_layers[0].weight,
                 composable_block_ids=(0, "block_0"),
@@ -151,8 +132,8 @@ class DistributorTest(DistributorInterfaceTest):
             ),
         )
         self.assertEqual(
-            self._distributor.global_block_info_list,
-            expected_global_block_info_list,
+            self._distributor.local_block_info_list,
+            expected_local_block_info_list,
         )
 
     def test_merge_and_block_gradients(self) -> None:

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -167,11 +167,10 @@ class SGDPreconditionerListTest(PreconditionerListTest):
 class AdagradPreconditionerListTest(PreconditionerListTest):
     def _instantiate_block_list(self) -> tuple[Tensor, ...]:
         # Because maximum_preconditioner_dim = 2, self._params[0] forms a block by itself,
-        # self._params[1] are split into two blocks, and self._params[2] forms a block by itself.
+        # and self._params[1] are split into two blocks.
         return (
             self._params[0],
             *torch.split(self._params[1], 2, dim=0),
-            self._params[2],
         )
 
     def _instantiate_preconditioner_list(
@@ -182,7 +181,6 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
             block_list=self._block_list,
             state=self._state,
             block_info_list=self._block_info_list,
-            distributor_selector=self._distributor_selector,
             **kwargs,
         )
 
@@ -190,16 +188,13 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
         self._params = (
             torch.tensor([1.0, 2.0]),
             torch.arange(6, dtype=torch.float).reshape(3, 2),
-            # Following param will not be used due to the distributor selector below.
-            torch.tensor([torch.nan, torch.nan]),
         )
         self._state = {  # type: ignore[var-annotated]
             self._params[0]: {},
             self._params[1]: {},
-            self._params[2]: {},
         }
         # Because maximum_preconditioner_dim = 2, self._params[0] forms a block by itself,
-        # self._params[1] are split into two blocks, and self._params[2] forms a block by itself.
+        # and self._params[1] are split into two blocks.
         self._block_info_list = (
             BlockInfo(
                 param=self._params[0],
@@ -213,13 +208,7 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
                 param=self._params[1],
                 composable_block_ids=(1, "block_1"),
             ),
-            BlockInfo(
-                param=self._params[2],
-                composable_block_ids=(2, "block_0"),
-            ),
         )
-        # Ignores the last block, which is self._params[2] itself.
-        self._distributor_selector = (True, True, True, False)
         super().setUp()
 
     def test_update_preconditioners_and_precondition(self) -> None:
@@ -295,7 +284,6 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
                         composable_block_ids=(0, "block_0"),
                     ),
                 ),
-                distributor_selector=(True,),
                 preconditioner_config=DefaultShampooConfig,
                 beta2=1.0,
             )
@@ -627,7 +615,6 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
             block_list=self._block_list,
             state=self._state,
             block_info_list=self._block_info_list,
-            distributor_selector=self._distributor_selector,
             factor_matrix_dtype=torch.float64,
             **kwargs,  # type: ignore[arg-type]
         )
@@ -871,7 +858,6 @@ class EigenvalueCorrectedShampooPreconditionerListTest(
             block_list=self._block_list,
             state=self._state,
             block_info_list=self._block_info_list,
-            distributor_selector=self._distributor_selector,
             factor_matrix_dtype=torch.float64,
             **kwargs,  # type: ignore[arg-type]
         )


### PR DESCRIPTION
Summary:
In the current Shampoo design, there are three major components: `DistributedShampoo`, which describes the high-level algorithm flow; `Distributor`, which manages the distribution of parameters for different computing paradigms (e.g., DDP, FSDP, HSDP, etc.); and `PreconditionerList`, which contains the detailed algorithm implementation.

The `Distributor` manages the distribution of parameters and then sends them to `DistributedShampoo` which invokes the corresponding algorithms implemented by each `PreconditionerList`.

Since the `Distributor` handles parameter distribution, ideally, downstream classes (i.e., `DistributedShampoo` and `PreconditionerList`) should not need to use `Distributor.distributor_selector` to compress parameters for their use. However, in the current implementation, such usages appear in both [`DistributedShampoo`](https://github.com/facebookresearch/optimizers/blob/5e14660cdf068ac1a2c5fd7ec63086a932eba611/distributed_shampoo/distributed_shampoo.py#L615-L619) and [`PreconditionerList`](https://github.com/facebookresearch/optimizers/blob/5e14660cdf068ac1a2c5fd7ec63086a932eba611/distributed_shampoo/utils/shampoo_preconditioner_list.py#L146-L147).

The main changes are listed as follows:
1. `Distributor` now only provides access to the local version of `params` and `block_info` to align with its responsibilities.
2. `Distributor` no longer needs to store `global_block_info_list`, the global version of `block_info`; instead, it stores `local_block_info_list`.
3. `PreconditionerList` no longer requires `distributor_selector` as an input argument because `Distributor` already performs this task.

Differential Revision: D64708506


