### PR TITLE
Invoke assertRaises* in non-context manager fashsion

### DIFF
--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -291,19 +291,18 @@ class ShampooHSDPDistributorTest(FSDPTest):
             num_trainers_per_group=3,
         )
 
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             ValueError,
             re.escape(
                 "Invalid number of trainers per group: 3. Must be between [1, 2] or set to -1."
             ),
-        ):
-            ShampooHSDPDistributorTest._train_model(
-                optim_factory=ShampooHSDPDistributorTest._shampoo_optim_factory(
-                    distributed_config=hsdp_config,
-                ),
-                model_factory=ShampooHSDPDistributorTest._model_factory(hsdp_config),
-                device=torch.device("cuda"),
-            )
+            ShampooHSDPDistributorTest._train_model,
+            optim_factory=ShampooHSDPDistributorTest._shampoo_optim_factory(
+                distributed_config=hsdp_config,
+            ),
+            model_factory=ShampooHSDPDistributorTest._model_factory(hsdp_config),
+            device=torch.device("cuda"),
+        )
 
     @skip_if_lt_x_gpu(4)
     def test_dist_is_initialized(self) -> None:
@@ -313,13 +312,11 @@ class ShampooHSDPDistributorTest(FSDPTest):
             device_mesh=mesh_2d,
         )
 
-        with mock.patch.object(
-            torch.distributed, "is_initialized", return_value=False
-        ), self.assertRaisesRegex(
-            RuntimeError,
-            re.escape("HSDPDistributor needs torch.distributed to be initialized!"),
-        ):
-            ShampooHSDPDistributorTest._train_model(
+        with mock.patch.object(torch.distributed, "is_initialized", return_value=False):
+            self.assertRaisesRegex(
+                RuntimeError,
+                re.escape("HSDPDistributor needs torch.distributed to be initialized!"),
+                ShampooHSDPDistributorTest._train_model,
                 optim_factory=ShampooHSDPDistributorTest._shampoo_optim_factory(
                     distributed_config=hsdp_config,
                 ),
@@ -341,13 +338,13 @@ class ShampooHSDPDistributorTest(FSDPTest):
         # Hijack the DeviceMesh.size() method to return 4 instead of 2 to bypass the check of num_trainers_per_group.
         with mock.patch.object(
             torch.distributed.device_mesh.DeviceMesh, "size", return_value=4
-        ), self.assertRaisesRegex(
-            ValueError,
-            re.escape(
-                "distributed_config.num_trainers_per_group=3 must divide self._replicated_group_size=4!"
-            ),
         ):
-            ShampooHSDPDistributorTest._train_model(
+            self.assertRaisesRegex(
+                ValueError,
+                re.escape(
+                    "distributed_config.num_trainers_per_group=3 must divide self._replicated_group_size=4!"
+                ),
+                ShampooHSDPDistributorTest._train_model,
                 optim_factory=ShampooHSDPDistributorTest._shampoo_optim_factory(
                     distributed_config=hsdp_config,
                 ),

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
@@ -330,21 +330,20 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
             num_trainers_per_group=3,
         )
 
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             ValueError,
             re.escape(
                 "Invalid number of trainers per group: 3. Must be between [1, 2] or set to -1."
             ),
-        ):
-            ShampooHybridShardDistributorTest._train_model(
-                optim_factory=ShampooHybridShardDistributorTest._shampoo_optim_factory(
-                    distributed_config=hybrid_shard_config,
-                ),
-                model_factory=ShampooHybridShardDistributorTest._model_factory(
-                    hybrid_shard_config
-                ),
-                device=torch.device("cuda"),
-            )
+            ShampooHybridShardDistributorTest._train_model,
+            optim_factory=ShampooHybridShardDistributorTest._shampoo_optim_factory(
+                distributed_config=hybrid_shard_config,
+            ),
+            model_factory=ShampooHybridShardDistributorTest._model_factory(
+                hybrid_shard_config
+            ),
+            device=torch.device("cuda"),
+        )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -356,15 +355,13 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
             device_mesh=mesh_2d,
         )
 
-        with mock.patch.object(
-            torch.distributed, "is_initialized", return_value=False
-        ), self.assertRaisesRegex(
-            RuntimeError,
-            re.escape(
-                "HybridShardDistributor needs torch.distributed to be initialized!"
-            ),
-        ):
-            ShampooHybridShardDistributorTest._train_model(
+        with mock.patch.object(torch.distributed, "is_initialized", return_value=False):
+            self.assertRaisesRegex(
+                RuntimeError,
+                re.escape(
+                    "HybridShardDistributor needs torch.distributed to be initialized!"
+                ),
+                ShampooHybridShardDistributorTest._train_model,
                 optim_factory=ShampooHybridShardDistributorTest._shampoo_optim_factory(
                     distributed_config=hybrid_shard_config,
                 ),
@@ -390,13 +387,13 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
         # Hijack the DeviceMesh.size() method to return 4 instead of 2 to bypass the check of num_trainers_per_group.
         with mock.patch.object(
             torch.distributed.device_mesh.DeviceMesh, "size", return_value=4
-        ), self.assertRaisesRegex(
-            ValueError,
-            re.escape(
-                "distributed_config.num_trainers_per_group=3 must divide self._replicated_group_size=4!"
-            ),
         ):
-            ShampooHybridShardDistributorTest._train_model(
+            self.assertRaisesRegex(
+                ValueError,
+                re.escape(
+                    "distributed_config.num_trainers_per_group=3 must divide self._replicated_group_size=4!"
+                ),
+                ShampooHybridShardDistributorTest._train_model,
                 optim_factory=ShampooHybridShardDistributorTest._shampoo_optim_factory(
                     distributed_config=hybrid_shard_config,
                 ),

--- a/distributed_shampoo/utils/tests/shampoo_checkpoint_utils_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_checkpoint_utils_test.py
@@ -186,13 +186,13 @@ class UpdateParamStateDictObjectTest(unittest.TestCase):
     def test_update_param_state_dict_object_with_missing_key(self) -> None:
         # Explicitly delete 'bar' from self._extracted_state_dict to simulate a missing key.
         self._extracted_state_dict.pop("bar")
-        with self.assertRaisesRegex(
-            KeyError, re.escape("Key bar not found in state dict to load.")
-        ):
-            update_param_state_dict_object(
-                current_param_state_dict=self._current_state_dict,
-                param_state_dict_to_load=self._extracted_state_dict,
-            )
+        self.assertRaisesRegex(
+            KeyError,
+            re.escape("Key bar not found in state dict to load."),
+            update_param_state_dict_object,
+            current_param_state_dict=self._current_state_dict,
+            param_state_dict_to_load=self._extracted_state_dict,
+        )
 
         # Disable enable_missing_key_check so the exception will be suppressed, and the value of 'bar' key will not be updated.
         update_param_state_dict_object(

--- a/distributed_shampoo/utils/tests/shampoo_fsdp_distributor_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_fsdp_distributor_test.py
@@ -38,13 +38,15 @@ class SplitTensorBlockRecoveryTest(unittest.TestCase):
         torch.testing.assert_close(actual_split_tensors, expected_split_tensors)
 
     def test_illegal_tensor_shard_size(self) -> None:
-        with self.assertRaisesRegex(ValueError, re.escape("Input tensor is not flat")):
-            FSDPDistributor._split_tensor_block_recovery(
-                tensor_shard=torch.randn((3, 4)),
-                original_shape=torch.Size((3, 4)),
-                start_idx=0,
-                end_idx=16,
-            )
+        self.assertRaisesRegex(
+            ValueError,
+            re.escape("Input tensor is not flat"),
+            FSDPDistributor._split_tensor_block_recovery,
+            tensor_shard=torch.randn((3, 4)),
+            original_shape=torch.Size((3, 4)),
+            start_idx=0,
+            end_idx=16,
+        )
 
     def test_split_tensor_block_recovery_for_one_dim(self) -> None:
         original_tensor = torch.arange(5)

--- a/distributed_shampoo/utils/tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_hsdp_distributor_test.py
@@ -38,13 +38,15 @@ class SplitTensorBlockRecoveryTest(unittest.TestCase):
         torch.testing.assert_close(actual_split_tensors, expected_split_tensors)
 
     def test_illegal_tensor_shard_size(self) -> None:
-        with self.assertRaisesRegex(ValueError, re.escape("Input tensor is not flat")):
-            HSDPDistributor._split_tensor_block_recovery(
-                tensor_shard=torch.randn((3, 4)),
-                original_shape=torch.Size((3, 4)),
-                start_idx=0,
-                end_idx=16,
-            )
+        self.assertRaisesRegex(
+            ValueError,
+            re.escape("Input tensor is not flat"),
+            HSDPDistributor._split_tensor_block_recovery,
+            tensor_shard=torch.randn((3, 4)),
+            original_shape=torch.Size((3, 4)),
+            start_idx=0,
+            end_idx=16,
+        )
 
     def test_split_tensor_block_recovery_for_one_dim(self) -> None:
         original_tensor = torch.arange(5)

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -315,19 +315,18 @@ class AbstractTest:
         def _test_raise_invalid_value_in_factor_matrix(
             self, invalid_value: float
         ) -> None:
-            with self.assertRaisesRegex(
+            self.assertRaisesRegex(
                 PreconditionerValueError,
                 re.escape(f"Encountered {str(invalid_value)} values in factor matrix"),
-            ):
-                self._preconditioner_list.update_preconditioners(
-                    masked_grad_list=(
-                        torch.tensor([invalid_value, invalid_value]),
-                        torch.eye(2) / torch.tensor(2.0).sqrt(),
-                        torch.tensor([[invalid_value, invalid_value]]),
-                    ),
-                    step=torch.tensor(1),
-                    perform_amortized_computation=True,
-                )
+                self._preconditioner_list.update_preconditioners,
+                masked_grad_list=(
+                    torch.tensor([invalid_value, invalid_value]),
+                    torch.eye(2) / torch.tensor(2.0).sqrt(),
+                    torch.tensor([[invalid_value, invalid_value]]),
+                ),
+                step=torch.tensor(1),
+                perform_amortized_computation=True,
+            )
 
         # Because nan as the input of self._preconditioner_list.update_preconditioners() would change the internal state to nan (and stayed as nan even after other updates),
         # we need to test the cases of nan and inf separately.
@@ -343,17 +342,16 @@ class AbstractTest:
             for invalid_value in (torch.nan, torch.inf):
                 with (
                     self.subTest(invalid_value=invalid_value),
-                    self.assertRaisesRegex(
-                        PreconditionerValueError,
-                        re.escape("Encountered nan or inf values in"),
-                    ),
                     mock.patch.object(
                         shampoo_preconditioner_list,
                         self._amortized_computation_function(),
                         side_effect=(torch.tensor([invalid_value]),),
                     ) as mock_amortized_computation,
                 ):
-                    self._preconditioner_list.update_preconditioners(
+                    self.assertRaisesRegex(
+                        PreconditionerValueError,
+                        re.escape("Encountered nan or inf values in"),
+                        self._preconditioner_list.update_preconditioners,
                         masked_grad_list=(
                             torch.tensor([1.0, 0.0]),
                             torch.eye(2) / torch.tensor(2.0).sqrt(),
@@ -522,12 +520,14 @@ class AbstractTest:
                 # Exactly at failure tolerance now.
                 with self.assertLogs(level="WARNING") as cm:
                     expected_error_message = r"The number of failed .* computations for factors \('0.block_0.0',\) exceeded the allowed tolerance\."
-                    with self.assertRaisesRegex(ValueError, expected_error_message):
-                        self._preconditioner_list.update_preconditioners(
-                            masked_grad_list=masked_grad_list,
-                            step=torch.tensor(step),
-                            perform_amortized_computation=True,
-                        )
+                    self.assertRaisesRegex(
+                        ValueError,
+                        expected_error_message,
+                        self._preconditioner_list.update_preconditioners,
+                        masked_grad_list=masked_grad_list,
+                        step=torch.tensor(step),
+                        perform_amortized_computation=True,
+                    )
                     # Check that the warning is logged for the failed amortized computation of the first matrix.
                     self.assertCountEqual(
                         # Only extracts the first sentence in the warning message for simple comparison.

--- a/distributed_shampoo/utils/tests/shampoo_quantization_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_quantization_test.py
@@ -84,27 +84,25 @@ class QuantizedTensorTest(unittest.TestCase):
             self._quantized_tensor = quantized_tensor_copy
 
     def test_invalid_quantized_data_type(self) -> None:
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             NotImplementedError,
             re.escape("Quantization for torch.int64 is not yet supported!"),
-        ):
-            _ = QuantizedTensor.init_from_dequantized_tensor(
-                dequantized_values=torch.rand(10),
-                quantized_dtype=torch.int64,
-                block_info=BlockInfo(torch.zeros(10), (0, "dummy")),
-            )
+            QuantizedTensor.init_from_dequantized_tensor,
+            dequantized_values=torch.rand(10),
+            quantized_dtype=torch.int64,
+            block_info=BlockInfo(torch.zeros(10), (0, "dummy")),
+        )
 
         quantized_tensor = QuantizedTensor(
             quantized_values=torch.zeros(10, dtype=torch.int64),
             block_info=BlockInfo(torch.zeros(10), (0, "dummy")),
         )
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             NotImplementedError,
             re.escape("Quantization for torch.int64 is not yet supported!"),
-        ):
-            quantized_tensor.dequantize(
-                dequantized_dtype=torch.float16,
-            )
+            quantized_tensor.dequantize,
+            dequantized_dtype=torch.float16,
+        )
 
 
 class QuantizedTensorListInitTest(unittest.TestCase):
@@ -113,13 +111,13 @@ class QuantizedTensorListInitTest(unittest.TestCase):
             shampoo_quantization,
             "isinstance",
             side_effect=lambda object, classinfo: False,
-        ), self.assertRaisesRegex(
-            TypeError,
-            re.escape(
-                "quantized_data must be collections.abc.Sequence[tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]] | collections.abc.Sequence[distributed_shampoo.utils.shampoo_quantization.QuantizedTensor] but get <class 'list'>"
-            ),
         ):
-            QuantizedTensorList(
+            self.assertRaisesRegex(
+                TypeError,
+                re.escape(
+                    "quantized_data must be collections.abc.Sequence[tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]] | collections.abc.Sequence[distributed_shampoo.utils.shampoo_quantization.QuantizedTensor] but get <class 'list'>"
+                ),
+                QuantizedTensorList,
                 quantized_data=[
                     (torch.randn(2, 2, dtype=torch.float16), None, None)
                     for _ in range(5)
@@ -129,20 +127,18 @@ class QuantizedTensorListInitTest(unittest.TestCase):
             )
 
     def test_invalid_computation_dtype(self) -> None:
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             AssertionError,
             re.escape(
                 "computation_dtype=torch.int64 is not supported! It must be one of (torch.float16, torch.bfloat16, torch.float32, torch.float64)!"
             ),
-        ):
-            QuantizedTensorList(
-                quantized_data=[
-                    (torch.randn(2, 2, dtype=torch.float16), None, None)
-                    for _ in range(5)
-                ],
-                quantized_dtype=torch.float16,
-                computation_dtype=torch.int64,
-            )
+            QuantizedTensorList,
+            quantized_data=[
+                (torch.randn(2, 2, dtype=torch.float16), None, None) for _ in range(5)
+            ],
+            quantized_dtype=torch.float16,
+            computation_dtype=torch.int64,
+        )
 
 
 class QuantizedTensorListTest(unittest.TestCase):
@@ -288,16 +284,15 @@ class QuantizedTensorListTest(unittest.TestCase):
             quantized_dtype=torch.int64,
             computation_dtype=torch.float64,
         )
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             NotImplementedError,
             re.escape("Quantization for torch.int64 is not yet supported!"),
-        ):
-            quantized_tensors.dequantize()
+            quantized_tensors.dequantize,
+        )
 
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             NotImplementedError,
             re.escape("Quantization for torch.int64 is not yet supported!"),
-        ):
-            quantized_tensors.quantize(
-                tensor_list=tuple(torch.rand(5) for _ in range(5))
-            )
+            quantized_tensors.quantize,
+            tensor_list=tuple(torch.rand(5) for _ in range(5)),
+        )

--- a/distributed_shampoo/utils/tests/shampoo_utils_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_utils_test.py
@@ -109,8 +109,13 @@ class CompressListTest(unittest.TestCase):
         self.assertTupleEqual(compress_list([1, 2, 3], (True, False, True)), (1, 3))
 
     def test_compress_list_with_different_size(self) -> None:
-        with self.assertRaisesRegex(AssertionError, re.escape("Inconsistent lengths")):
-            compress_list(complete_list=[1, 2, 3], selector=(True, False))
+        self.assertRaisesRegex(
+            AssertionError,
+            re.escape("Inconsistent lengths"),
+            compress_list,
+            complete_list=[1, 2, 3],
+            selector=(True, False),
+        )
 
 
 class GetDTypeSizeTest(unittest.TestCase):


### PR DESCRIPTION
Summary: It was discovered that internal and external Ruff formater formats differently on codes with multiple context managers and this will convert the `assertRaises*` usages into non-context manager fashion. [This was caused some OSS CI complains before](https://github.com/facebookresearch/optimizers/pull/65), and this diff should reduce the chance of discrepency between diff Ruff formater setting on multiple context managers.

Differential Revision: D67681063


