### PR TITLE
Refactor AdamGraftingConfig to inherit from RMSPropGraftingConfig

### DIFF
--- a/distributed_shampoo/shampoo_types.py
+++ b/distributed_shampoo/shampoo_types.py
@@ -326,7 +326,7 @@ class RMSpropGraftingConfig(AdaGradGraftingConfig):
 
 
 @dataclass(kw_only=True)
-class AdamGraftingConfig(AdaGradGraftingConfig):
+class AdamGraftingConfig(RMSpropGraftingConfig):
     """Configuration for grafting from Adam.
 
     Args:
@@ -337,10 +337,3 @@ class AdamGraftingConfig(AdaGradGraftingConfig):
     """
 
     beta2: float = 0.999
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        if not 0.0 < self.beta2 <= 1.0:
-            raise ValueError(
-                f"Invalid grafting beta2 parameter: {self.beta2}. Must be in (0.0, 1.0]."
-            )


### PR DESCRIPTION
Summary:
This diff refactors `AdamGraftingConfig` to inherit from `RMSPropGraftingConfig`, taking advantage of the fact that `Adam` is essentially `RMSProp` with momentum. This inheritance was previously blocked by an `isinstance` check, but is now enabled by the switch to `type` checking.

Additionally, this diff fixes an oversight in [the previous `type.__subclasses__()` refactor](https://github.com/facebookresearch/optimizers/pull/72), ensuring that parent classes are properly included.

Differential Revision: D67719358


