### PR TITLE
Open-sourced update on 02/20/2024

### DIFF
--- a/distributed_shampoo/shampoo_types.py
+++ b/distributed_shampoo/shampoo_types.py
@@ -83,7 +83,7 @@ class PreconditionerValueError(ValueError):
 class PreconditionerConfig(AbstractDataclass):
     """Configuration for preconditioner computation in DistributedShampoo.
 
-    Args:
+    Attributes:
         amortized_computation_config (MatrixFunctionConfig): Configuration for the amortized computation, e.g., inverse-root or eigenvector computation.
         num_tolerated_failed_amortized_computations (int): Number of failed amortized computations to tolerate before raising an error. (Default: 3)
 
@@ -103,8 +103,9 @@ class PreconditionerConfig(AbstractDataclass):
 class ShampooPreconditionerConfig(PreconditionerConfig):
     """Configuration for Shampoo preconditioner computation.
 
-    Args:
+    Attributes:
         amortized_computation_config (RootInvConfig): Configuration for the inverse-root computation. (Default: DefaultEigenConfig)
+        num_tolerated_failed_amortized_computations (int): Number of failed amortized computations to tolerate before raising an error. (Default: 3)
 
     """
 
@@ -120,9 +121,10 @@ DefaultShampooConfig = ShampooPreconditionerConfig()
 class EigenvalueCorrectedShampooPreconditionerConfig(PreconditionerConfig):
     """Configuration for eigenvalue-corrected Shampoo/SOAP preconditioner computation.
 
-    Args:
+    Attributes:
         amortized_computation_config (EigenvectorConfig): Configuration for the eigenvector computation.
             (Default: DefaultEighEigenvectorConfig)
+        num_tolerated_failed_amortized_computations (int): Number of failed amortized computations to tolerate before raising an error. (Default: 3)
 
     """
 
@@ -143,7 +145,7 @@ DefaultSOAPConfig = EigenvalueCorrectedShampooPreconditionerConfig(
 class FSDPParameterMetadata:
     """FSDP Metadata for a parameter.
 
-    Args:
+    Attributes:
         fqn (str): Fully qualified name of the parameter.
         shape (torch.Size): Shape of the parameter.
         numel (int): Number of elements in the parameter.
@@ -172,7 +174,7 @@ class DDPShampooConfig(DistributedConfig):
 
     Enables distributed computation and optimizer states (like ZeRO-1) via DTensor for Shampoo.
 
-    Args:
+    Attributes:
         communication_dtype (CommunicationDType): Data type for communication between ranks. (Default: DEFAULT)
         num_trainers_per_group (int): Number of GPUs per distributed process group for distributed computation/memory.
             If num_trainers_per_group = -1 is used, then defaults to using the LOCAL_WORLD_SIZE. (Default: -1)
@@ -192,7 +194,7 @@ class FSDPShampooConfig(DistributedConfig):
 
     Passes in additional metadata necessary to run FSDP Shampoo.
 
-    Args:
+    Attributes:
         param_to_metadata (dict[Parameter, FSDPParameterMetadata]): Dictionary mapping parameter to its metadata from FSDP.
 
     """
@@ -207,7 +209,7 @@ class HSDPShampooConfig(FSDPShampooConfig, DDPShampooConfig):
     Enables distributed computation and optimizer states (like ZeRO-1) via DTensor for Shampoo across ranks with shared
     parameters between different HSDP process groups.
 
-    Args:
+    Attributes:
         device_mesh (torch.distributed.device_mesh.DeviceMesh): A 2D device mesh that specifies the layout of the numbers of
             shard and replicate dimensions.
         param_to_metadata (dict[Parameter, FSDPParameterMetadata]): Dictionary mapping parameter to its metadata from HSDP.
@@ -238,7 +240,7 @@ class HybridShardShampooConfig(FullyShardShampooConfig, DDPShampooConfig):
     Enables distributed computation and optimizer states (like ZeRO-1) via DTensor for Shampoo across ranks with shared
     parameters between different Hybrid Shard process groups.
 
-    Args:
+    Attributes:
         device_mesh (torch.distributed.device_mesh.DeviceMesh): Device mesh for Hybrid Shard.
         communication_dtype (CommunicationDType): Data type for communication between ranks. (Default: DEFAULT)
         num_trainers_per_group (int): Number of GPUs per distributed process group for distributed computation/memory.
@@ -259,7 +261,7 @@ class ShampooPT2CompileConfig:
     Enables Shampoo pytorch compilation with configure to speed up model training.
     For more details: https://pytorch.org/get-started/pytorch-2.0/
 
-    Args:
+    Attributes:
         pytorch_compile_backend (str): The backend for PT2 compilation. More info about PT2 backends:
             https://pytorch.org/docs/stable/torch.compiler.html (Default: inductor)
         enable_shampoo_pt2_dynamic_shape (bool | None): Compile Shampoo in static, dynamic or auto-dynamic shape mode (Default: False).
@@ -291,7 +293,7 @@ class SGDGraftingConfig(GraftingConfig):
 class AdaGradGraftingConfig(GraftingConfig):
     """Configuration for grafting from AdaGrad.
 
-    Args:
+    Attributes:
         epsilon (float): Epsilon term for regularizing square-root of the aggregated second moment to ensure positive definiteness.
             (Default: 1e-10)
 
@@ -308,7 +310,7 @@ class AdaGradGraftingConfig(GraftingConfig):
 class RMSpropGraftingConfig(AdaGradGraftingConfig):
     """Configuration for grafting from RMSprop.
 
-    Args:
+    Attributes:
         beta2 (float): Exponential moving average factor for second moment. (Default: 0.99)
         epsilon (float): Epsilon term for regularizing square-root of the second moment to ensure positive definiteness.
             (Default: 1e-10)
@@ -329,7 +331,7 @@ class RMSpropGraftingConfig(AdaGradGraftingConfig):
 class AdamGraftingConfig(RMSpropGraftingConfig):
     """Configuration for grafting from Adam.
 
-    Args:
+    Attributes:
         beta2 (float): Exponential moving average factor for second moment. (Default: 0.999)
         epsilon (float): Epsilon term for regularizing square-root of the second moment to ensure positive definiteness.
             (Default: 1e-10)

--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -28,7 +28,6 @@ from distributed_shampoo.shampoo_types import (
     PreconditionerConfig,
     SGDGraftingConfig,
     ShampooPreconditionerConfig,
-    ShampooPT2CompileConfig,
 )
 from torch import nn
 
@@ -149,18 +148,6 @@ class DistributedShampooInitTest(unittest.TestCase):
                     **incorrect_hyperparameter_setting,
                 )
 
-    def test_invalid_cuda_pytorch_compile_setting(self) -> None:
-        with mock.patch.object(torch.cuda, "is_available", return_value=False):
-            self.assertRaisesRegex(
-                ValueError,
-                re.escape(
-                    "Backend does NOT support Pytorch 2.0 compile. Switch to shampoo_pt2_compile_config=None."
-                ),
-                DistributedShampoo,
-                self._model.parameters(),
-                shampoo_pt2_compile_config=ShampooPT2CompileConfig(),
-            )
-
     def test_nesterov_and_zero_momentum(self) -> None:
         with self.assertLogs(
             level="WARNING",
@@ -192,24 +179,6 @@ class DistributedShampooInitTest(unittest.TestCase):
                 DistributedShampoo,
                 params=self._model.parameters(),
                 distributed_config=DDPShampooConfig(),
-            )
-
-    def test_setting_exponent_multiplier_with_eigen_config(self) -> None:
-        with self.assertLogs(
-            level="WARNING",
-        ) as cm:
-            DistributedShampoo(
-                self._model.parameters(),
-                lr=0.01,
-                start_preconditioning_step=1,
-                exponent_multiplier=2.0,
-                preconditioner_config=DefaultShampooConfig,
-            )
-            self.assertCountEqual(
-                [r.msg for r in cm.records],
-                [
-                    "exponent_multiplier=2.0 is deprecating. Please consider using EigenConfig.exponent_multiplier directly and setting exponent_multipler=None instead in the future."
-                ],
             )
 
 

--- a/distributed_shampoo/utils/shampoo_fsdp_utils.py
+++ b/distributed_shampoo/utils/shampoo_fsdp_utils.py
@@ -13,6 +13,8 @@ import torch
 from distributed_shampoo.shampoo_types import FSDPParameterMetadata
 
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
+
+from torch.distributed.fsdp._init_utils import HYBRID_SHARDING_STRATEGIES
 from torch.distributed.tensor import DTensor
 from torch.nn import Parameter
 
@@ -148,8 +150,7 @@ def parse_fsdp_params(
         and param_metadata[param].sharding_strategy
         in [ShardingStrategy.FULL_SHARD, ShardingStrategy.SHARD_GRAD_OP],
         hsdp_criteria=lambda param: param in param_metadata
-        and param_metadata[param].sharding_strategy
-        in [ShardingStrategy.HYBRID_SHARD, ShardingStrategy._HYBRID_SHARD_ZERO2],
+        and param_metadata[param].sharding_strategy in HYBRID_SHARDING_STRATEGIES,
         other_criteria=lambda param: param not in param_metadata
         or param_metadata[param].sharding_strategy == ShardingStrategy.NO_SHARD,
     )

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -276,7 +276,13 @@ class AdagradPreconditionerList(PreconditionerList):
 
 @dataclass
 class BaseShampooKroneckerFactors(OptimizerModule):
-    """Base class for Shampoo Kronecker factors."""
+    """Base class for Shampoo Kronecker factors.
+
+    Attributes:
+        factor_matrices (tuple[Tensor, ...]): A tuple of tensors representing the factor matrices.
+        factor_matrix_indices (tuple[str, ...]): A tuple of strings representing the indices of the factor matrices.
+        is_factor_matrices_diagonal (tuple[Tensor, ...]): A tuple of tensors indicating if the factor matrices are diagonal.
+    """
 
     factor_matrices: tuple[Tensor, ...]
     factor_matrix_indices: tuple[str, ...]
@@ -292,7 +298,14 @@ class BaseShampooKroneckerFactors(OptimizerModule):
 
 @dataclass
 class ShampooKroneckerFactorsState(BaseShampooKroneckerFactors):
-    """Shampoo Kronecker factors (wrapped) for storing in the optimizer state."""
+    """Shampoo Kronecker factors (wrapped) for storing in the optimizer state.
+
+    Attributes:
+        inv_factor_matrices (tuple[Tensor, ...]): A tuple of tensors representing the inverse of the factor matrices.
+        factor_matrices (tuple[Tensor, ...]): A tuple of tensors representing the factor matrices.
+        factor_matrix_indices (tuple[str, ...]): A tuple of strings representing the indices of the factor matrices.
+        is_factor_matrices_diagonal (tuple[Tensor, ...]): A tuple of tensors indicating if the factor matrices are diagonal.
+    """
 
     inv_factor_matrices: tuple[Tensor, ...]
 
@@ -303,7 +316,14 @@ class ShampooKroneckerFactorsState(BaseShampooKroneckerFactors):
 
 @dataclass
 class ShampooKroneckerFactorsList(BaseShampooKroneckerFactors):
-    """Shampoo Kronecker factors (unwrapped) for operations during optimizer computation."""
+    """Shampoo Kronecker factors (unwrapped) for operations during optimizer computation.
+
+    Attributes:
+        inv_factor_matrices (tuple[Tensor, ...]): A tuple of tensors representing the inverse of the factor matrices.
+        factor_matrices (tuple[Tensor, ...]): A tuple of tensors representing the factor matrices.
+        factor_matrix_indices (tuple[str, ...]): A tuple of strings representing the indices of the factor matrices.
+        is_factor_matrices_diagonal (tuple[Tensor, ...]): A tuple of tensors indicating if the factor matrices are diagonal.
+    """
 
     inv_factor_matrices: tuple[Tensor, ...]
 
@@ -314,7 +334,15 @@ class ShampooKroneckerFactorsList(BaseShampooKroneckerFactors):
 
 @dataclass
 class EigenvalueCorrectedShampooKroneckerFactorsState(BaseShampooKroneckerFactors):
-    """Eigenvalue-corrected Shampoo Kronecker factors (wrapped) for storing in the optimizer state."""
+    """Eigenvalue-corrected Shampoo Kronecker factors (wrapped) for storing in the optimizer state.
+
+    Attributes:
+        factor_matrices_eigenvectors (tuple[Tensor, ...]): A tuple of tensors representing the eigenvectors of the factor matrices.
+        corrected_eigenvalues (Tensor): A tensor representing the corrected eigenvalues.
+        factor_matrices (tuple[Tensor, ...]): A tuple of tensors representing the factor matrices.
+        factor_matrix_indices (tuple[str, ...]): A tuple of strings representing the indices of the factor matrices.
+        is_factor_matrices_diagonal (tuple[Tensor, ...]): A tuple of tensors indicating if the factor matrices are diagonal.
+    """
 
     factor_matrices_eigenvectors: tuple[Tensor, ...]
     corrected_eigenvalues: Tensor
@@ -326,7 +354,15 @@ class EigenvalueCorrectedShampooKroneckerFactorsState(BaseShampooKroneckerFactor
 
 @dataclass
 class EigenvalueCorrectedShampooKroneckerFactorsList(BaseShampooKroneckerFactors):
-    """Eigenvalue-corrected Shampoo Kronecker factors (unwrapped) for operations during optimizer computation."""
+    """Eigenvalue-corrected Shampoo Kronecker factors (unwrapped) for operations during optimizer computation.
+
+    Attributes:
+        factor_matrices_eigenvectors (tuple[Tensor, ...]): A tuple of tensors representing the eigenvectors of the factor matrices.
+        corrected_eigenvalues (Tensor): A tensor representing the corrected eigenvalues.
+        factor_matrices (tuple[Tensor, ...]): A tuple of tensors representing the factor matrices.
+        factor_matrix_indices (tuple[str, ...]): A tuple of strings representing the indices of the factor matrices.
+        is_factor_matrices_diagonal (tuple[Tensor, ...]): A tuple of tensors indicating if the factor matrices are diagonal.
+    """
 
     factor_matrices_eigenvectors: tuple[Tensor, ...]
     corrected_eigenvalues: Tensor

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -301,9 +301,6 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
 # Use outer class as wrapper to avoid running the abstract test.
 class AbstractTest:
     class BaseShampooPreconditionerListTest(abc.ABC, AdagradPreconditionerListTest):
-        # Number of calls to the amortized computation function per update.
-        NUM_AMORTIZED_COMPUTATION_CALLS = 5
-
         @abc.abstractmethod
         def _amortized_computation_function(self) -> str: ...
 
@@ -406,16 +403,19 @@ class AbstractTest:
                 torch.tensor([[0.0, 1.0]]),
             )
 
+            # Number of calls to the amortized computation function per update.
+            NUM_AMORTIZED_COMPUTATION_CALLS = 5
+
             # Initialize step counter.
             step = 1
             # Define the side effect for each call of the amortized computation function.
             fail = ValueError
             success = torch.tensor([1.0])
-            all_but_one_fail = (fail,) * (self.NUM_AMORTIZED_COMPUTATION_CALLS - 1) + (
+            all_but_one_fail = (fail,) * (NUM_AMORTIZED_COMPUTATION_CALLS - 1) + (
                 success,
             )
-            all_fail = (fail,) * self.NUM_AMORTIZED_COMPUTATION_CALLS
-            all_success = (success,) * self.NUM_AMORTIZED_COMPUTATION_CALLS
+            all_fail = (fail,) * NUM_AMORTIZED_COMPUTATION_CALLS
+            all_success = (success,) * NUM_AMORTIZED_COMPUTATION_CALLS
             with mock.patch.object(
                 shampoo_preconditioner_list,
                 self._amortized_computation_function(),
@@ -633,7 +633,7 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
             G2 = [0, 1]^T
 
             L = G1 * G1^T + G2 * G2^T = [[1, 0], [0, 1]]
-            P = L^{-1/4} G2 = [0, 1]^T = G2
+            P = L^{-1/2} G2 = [0, 1]^T = G2
 
         (2) Tensor of Size 2 x 2
             G1 = [[1, 0], [0, 1]] / sqrt(2)


### PR DESCRIPTION
Summary:
1. Remove `exponent_multiplier` in the hyperparameters.
2. Add `eigen_decomp_offload_device` in `_matrix_inverse_root_eigen()`.
3. `dataclass` docstrings groomings.
4. Remove PyTorch 2.0 compile check with cuda due to its limitation to Nvidia GPU only when other accelerators are also available; this makes the config check pure-algorithmic setting only.
5. Add `eigen_decomp_offload_device` option in `EigenvalueDecompositionConfig` to enable offloading eigen decomposition to target device.

Differential Revision: D69944184


