### PR TITLE
Fix RMSprop spelling

### DIFF
--- a/distributed_shampoo/README.md
+++ b/distributed_shampoo/README.md
@@ -26,7 +26,7 @@ Key distinctives of this implementation include:
 - Learning rate grafting [3]. Our version of grafting only grafts the second moment/diagonal preconditioner. Momentum/first moment updates are performed separate from grafting. Supports the methods:
     - SGD
     - Adagrad
-    - RMSProp
+    - RMSprop
     - Adam
 - Supports both normal and AdamW (decoupled) weight decay.
 - Incorporates exponential moving averaging (with or without bias correction) to the estimate the first moment (akin to Adam).

--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -113,7 +113,7 @@ class DistributedShampoo(torch.optim.Optimizer):
             - GraftingType.NONE: Performs no grafting.
             - GraftingType.SGD: Grafts the stochastic gradient method.
             - GraftingType.ADAGRAD: Grafts the Adagrad method.
-            - GraftingType.RMSPROP: Grafts the RMSProp method.
+            - GraftingType.RMSPROP: Grafts the RMSprop method.
             - GraftingType.ADAM: Grafts the Adam method.
 
         NOTE: These methods do not graft the first-moment component - it is entirely based upon grafting using the

--- a/distributed_shampoo/gpu_tests/shampoo_eigenvalue_correction_test.py
+++ b/distributed_shampoo/gpu_tests/shampoo_eigenvalue_correction_test.py
@@ -33,7 +33,7 @@ from torch.optim.rmsprop import RMSprop
 
 
 # Note: We have to set the epsilon to a very small value (i.e., 1e-15) due to the
-# the place epsilon is added in the PyTorch optimizers (i.e., AdaGrad, RMSProp, Adam, AdamW)
+# the place epsilon is added in the PyTorch optimizers (i.e., AdaGrad, RMSprop, Adam, AdamW)
 # and Distributed Shampoo.
 # The PyTorch optimizers add epsilon outside of the square root, and Distributed Shampoo
 # adds epsilon inside of the square root.

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -126,14 +126,14 @@ class SGDPreconditionerList(PreconditionerList):
 
 
 class AdagradPreconditionerList(PreconditionerList):
-    """Adagrad / Adam / RMSProp preconditioners for a list of parameters.
+    """Adagrad / Adam / RMSprop preconditioners for a list of parameters.
 
     Operations are performed in-place with foreach operators.
 
     NOTE: Does not support sparse gradients at this time.
 
     To enable Adagrad, set beta2 = 1.0.
-    To enable RMSProp, set beta2 = 0.999.
+    To enable RMSprop, set beta2 = 0.999.
     To enable Adam, set beta2 = 0.999, use_bias_correction = True.
 
     Other variants can also be specified.


### PR DESCRIPTION
Make spelling consistent with the [corresponding PyTorch optimizer](https://pytorch.org/docs/stable/generated/torch.optim.RMSprop.html).