### PR TITLE
Ensure PATH compatibility for local GitHub Actions test

### DIFF
--- a/.github/workflows/type-check.yaml
+++ b/.github/workflows/type-check.yaml
@@ -10,11 +10,15 @@ jobs:
         - name: Set up and update uv.
           run: |
             curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
             uv self update
         - name: Install Python.
-          run: uv python install 3.10
+          run: |
+            export PATH="$HOME/.local/bin:$PATH"
+            uv python install 3.10
         - name: Create venv and install the package.
           run: |
+            export PATH="$HOME/.local/bin:$PATH"
             uv venv && source .venv/bin/activate
             uv pip install -e ".[dev]"
         - name: Run type checking with mypy.


### PR DESCRIPTION
This update was discussed with @runame in #94.

Althought [code convention](https://github.com/facebookresearch/optimizers/blob/main/CONTRIBUTING.md) requires `make`, `act` is a useful tool for the contributor's local test.

But when contributors tried local testing with `act`, sometimes it failed because `act` failed to find the local path of `uv`.

So I explicitly configured it for a bug fix.