### PR TITLE
Fix mypy complain on `init_device_mesh()` usage in `hybrid_shard_cifar10_example.py`

### DIFF
--- a/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     device_mesh = init_device_mesh(
         "cuda",
         (args.dp_replicate_degree, WORLD_RANK // args.dp_replicate_degree),
-        ("dp_replicate", "dp_shard"),
+        mesh_dim_names=("dp_replicate", "dp_shard"),
     )
 
     model, optimizer, loss_fn = create_model_and_optimizer_and_loss_fn(


### PR DESCRIPTION
Summary: `init_device_mesh()` requires 3rd argument to be keyed only.

Differential Revision: D72029173


