### PR TITLE
Upgrade to PyTorch 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file for how to help out.
 Optimizers is released under the [BSD license](LICENSE).
 
 ## Installation and Dependencies
-This code requires `python>=3.12` and `torch>=2.5.0`.
+This code requires `python>=3.12` and `torch>=2.7.0`.
 Install `distributed_shampoo` with all dependencies:
 ```bash
 git clone git@github.com:facebookresearch/optimizers.git

--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -37,7 +37,7 @@ from distributed_shampoo.tests.shampoo_test_utils import (
 )
 from matrix_functions_types import DefaultEigendecompositionConfig
 
-from torch import distributed as dist, tensor
+from torch import distributed as dist, nn, tensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate
@@ -192,6 +192,7 @@ class AbstractTest:
                 num_steps=num_steps,
             )
 
+            assert isinstance(model, nn.Module)
             assert isinstance(optimizer, DistributedShampoo)
             # Retrieve the distributed state dictionary of the first layer (i.e., the only layer) from the optimizer.
             distributed_state_dict = optimizer.distributed_state_dict(
@@ -414,6 +415,7 @@ class AbstractTest:
                 ),
                 num_steps=steps_with_gradients,
             )
+            assert isinstance(model, nn.Module)
 
             steps_without_gradients = 3
             for _ in range(steps_without_gradients):
@@ -456,6 +458,7 @@ class AbstractTest:
                 ),
                 num_steps=num_steps,
             )
+            assert isinstance(model, nn.Module)
 
             assert isinstance(optimizer, DistributedShampoo)
             # For each rank, no matter getting gradients or not, the step should be updated.

--- a/distributed_shampoo/utils/gpu_tests/shampoo_dist_utils_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_dist_utils_test.py
@@ -9,6 +9,8 @@ LICENSE file in the root directory of this source tree.
 
 #!/usr/bin/env python3
 
+from functools import partial
+from operator import attrgetter
 from unittest import mock
 
 import torch
@@ -42,11 +44,12 @@ class ShampooDistUtilsTest(DTensorTestBase):
             (shard_mesh.get_group(), replicate_mesh.get_group()),
         )
 
-    @with_comms  # type: ignore
+    @with_comms
     def test_get_device_mesh(self) -> None:
         mesh = tuple(
             map(
-                tuple,  # type: ignore
+                # Some type-checkers are not able to recognize the `tuple` below as a function. Use `partial` here to explicitly make a Callable for those type-checkers.
+                partial(tuple),
                 torch.tensor(range(self.world_size))
                 .view(-1, self.world_size // 2)
                 .tolist(),
@@ -55,7 +58,7 @@ class ShampooDistUtilsTest(DTensorTestBase):
 
         self._verify_deivce_mesh(
             device_mesh=get_device_mesh(
-                device_type=self.device_type,  # type: ignore
+                device_type=attrgetter("device_type")(self),
                 mesh=mesh,
                 mesh_dim_names=("replicate", "shard"),
             )
@@ -69,7 +72,7 @@ class ShampooDistUtilsTest(DTensorTestBase):
             "__init__",
         ) as mock_device_mesh_init:
             device_mesh = get_device_mesh(
-                device_type=self.device_type,  # type: ignore
+                device_type=attrgetter("device_type")(self),
                 mesh=mesh,
                 mesh_dim_names=("replicate", "shard"),
             )

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
@@ -68,6 +68,7 @@ class ShampooFSDPDistributorTest(FSDPTest):
             fill=0.01,
             post_model_decoration=post_model_decoration,
         )
+        assert isinstance(model, nn.Module)
         if isinstance(distributed_config, FSDPShampooConfig):
             assert (
                 sum(param.numel() for param in model.parameters())
@@ -113,6 +114,7 @@ class ShampooFSDPDistributorTest(FSDPTest):
             ),
             num_steps=steps_with_gradients,
         )
+        assert isinstance(model, nn.Module)
 
         steps_without_gradients = 3
         for _ in range(steps_without_gradients):

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
@@ -165,7 +165,7 @@ class ShampooFSDPDistributorTest(FSDPTest):
         state_dict = optimizer.distributed_state_dict(
             key_to_param=model.named_parameters()
         )
-        flattened_state_dict = flatten_state_dict(state_dict)[0]
+        flattened_state_dict = flatten_state_dict(state_dict["state"])[0]
         rank = dist.get_rank()
         matches = 0
         for key in flattened_state_dict.keys():

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_utils_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_utils_test.py
@@ -35,6 +35,7 @@ def _create_model_and_params(
     model, _, _, _ = construct_training_problem(
         model_linear_layers_dims, model_dead_layers_dims=None, fill=(1.0, 2.0)
     )
+    assert isinstance(model, nn.Module)
     return model, list(model.parameters())
 
 

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -80,6 +80,7 @@ class ShampooHSDPDistributorTest(FSDPTest):
             fill=0.01,
             post_model_decoration=post_model_decoration,
         )
+        assert isinstance(model, nn.Module)
         if isinstance(distributed_config, HSDPShampooConfig):
             assert (
                 sum(param.numel() for param in model.parameters())
@@ -177,6 +178,7 @@ class ShampooHSDPDistributorTest(FSDPTest):
                 distributed_config=hsdp_config,
             ),
         )
+        assert isinstance(model, nn.Module)
         assert isinstance(optimizer, DistributedShampoo)
         state_dict = optimizer.distributed_state_dict(
             key_to_param=model.named_parameters()
@@ -224,6 +226,7 @@ class ShampooHSDPDistributorTest(FSDPTest):
             ),
             num_steps=steps_with_gradients,
         )
+        assert isinstance(model, nn.Module)
 
         steps_without_gradients = 3
         for _ in range(steps_without_gradients):
@@ -260,6 +263,7 @@ class ShampooHSDPDistributorTest(FSDPTest):
             ),
             distributed_config=hsdp_config,
         )[0]
+        assert isinstance(model, nn.Module)
 
         self.assertRaisesRegex(
             ValueError,

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -181,7 +181,7 @@ class ShampooHSDPDistributorTest(FSDPTest):
         state_dict = optimizer.distributed_state_dict(
             key_to_param=model.named_parameters()
         )
-        flattened_state_dict = flatten_state_dict(state_dict)[0]
+        flattened_state_dict = flatten_state_dict(state_dict["state"])[0]
 
         # Note that we get the local rank corresponding to the second mesh dimension
         # because the first mesh dimension corresponds to replication and the second

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
@@ -264,7 +264,7 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
         state_dict = optimizer.distributed_state_dict(
             key_to_param=model.named_parameters()
         )
-        flattened_state_dict = flatten_state_dict(state_dict)[0]
+        flattened_state_dict = flatten_state_dict(state_dict["state"])[0]
 
         # Note that we get the local rank corresponding to the second mesh dimension
         # because the first mesh dimension corresponds to replication and the second

--- a/distributed_shampoo/utils/tests/shampoo_distributor_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_distributor_test.py
@@ -21,6 +21,7 @@ from distributed_shampoo.utils.shampoo_distributor import (
     Distributor,
     DistributorInterface,
 )
+from torch import nn
 
 
 class DistributorInterfaceTest(unittest.TestCase):
@@ -34,6 +35,7 @@ class DistributorInterfaceTest(unittest.TestCase):
         self._model, _, _, _ = construct_training_problem(
             (10, 5), model_dead_layers_dims=None, bias=True, fill=0.0
         )
+        assert isinstance(self._model, nn.Module)
         self._param_group = DistributedShampoo(
             self._model.parameters(),
             lr=0.01,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "torch-shampoo"
 version = "1.0.0"
 dependencies = [
-    "torch>=2.5.0,<2.6",
+    "torch>=2.7.0",
 ]
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
This diff upgrades the optimizers library to PyTorch 2.7.0. The changes include upgrading the required version of PyTorch and updating the code to work with the new version due to type checking complains.

Differential Revision: D72031480


