### PR TITLE
Fix the statistics initializations of eigendecompose Shampoo and eigenvalue-corrected Shampoo

### DIFF
--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -1257,9 +1257,10 @@ class EigendecomposedShampooPreconditionerList(
                     if isinstance(
                         eigendecomposition_config, QREigendecompositionConfig
                     ):
+                        # Due to the use of QR algorithm, we need to pass in the previous eigenvectors with the same type as the input matrix, i.e., bias_corrected_factor_matrix.
                         eigendecomposition_config.eigenvectors_estimate = (
                             factor_matrix_eigenvectors
-                        )
+                        ).to(dtype=bias_corrected_factor_matrix.dtype)
                     try:
                         computed_eigenvalues, computed_eigenvectors = (
                             matrix_eigendecomposition(
@@ -1268,6 +1269,8 @@ class EigendecomposedShampooPreconditionerList(
                                 is_diagonal=False,
                             )
                         )
+                        computed_eigenvalues.to(dtype=factor_matrix_eigenvalues.dtype)
+                        computed_eigenvectors.to(dtype=factor_matrix_eigenvectors.dtype)
                         # Add success to success tracker.
                         success_tracker.append(True)
                     except Exception as exception:
@@ -1551,15 +1554,16 @@ class EigenvalueCorrectedShampooPreconditionerList(
                     if isinstance(
                         eigendecomposition_config, QREigendecompositionConfig
                     ):
+                        # Due to the use of QR algorithm, we need to pass in the previous eigenvectors with the same type as the input matrix, i.e., factor_matrix.
                         eigendecomposition_config.eigenvectors_estimate = (
                             factor_matrix_eigenvectors
-                        )
+                        ).to(dtype=factor_matrix.dtype)
                     try:
                         computed_eigenvectors = matrix_eigendecomposition(
                             A=factor_matrix,
                             eigendecomposition_config=eigendecomposition_config,
                             is_diagonal=False,
-                        )[1]
+                        )[1].to(dtype=factor_matrix_eigenvectors.dtype)
                         # Add success to success tracker.
                         success_tracker.append(True)
                     except Exception as exception:

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -1105,6 +1105,10 @@ class EigendecomposedShampooPreconditionerList(
             )
             for dim in preconditioned_dims
         )
+        # Initialize factor_matrices_eigenvectors as identity matrices.
+        for t in factor_matrices_eigenvectors:
+            block_info.get_tensor(t).fill_diagonal_(1.0)
+
         factor_matrices_eigenvalues = tuple(
             block_info.allocate_zeros_tensor(
                 size=(dim,),
@@ -1113,6 +1117,9 @@ class EigendecomposedShampooPreconditionerList(
             )
             for dim in preconditioned_dims
         )
+        # Initialize factor_matrices_eigenvalues all ones.
+        for t in factor_matrices_eigenvalues:
+            block_info.get_tensor(t).fill_(1.0)
 
         base_kronecker_factors = self._create_base_kronecker_factors(
             block_info=block_info, preconditioned_dims=preconditioned_dims
@@ -1333,6 +1340,10 @@ class EigenvalueCorrectedShampooPreconditionerList(
             )
             for dim in preconditioned_dims
         )
+        # Initialize factor_matrices_eigenvectors as identity matrices.
+        for t in factor_matrices_eigenvectors:
+            block_info.get_tensor(t).fill_diagonal_(1.0)
+
         corrected_eigenvalues = block_info.allocate_zeros_tensor(
             # Note that the corrected eigenvalues are not affected by the preconditioned_dims.
             size=tuple(dims),

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -278,11 +278,11 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
         BaseShampooPreconditionerList.__abstractmethods__ = frozenset()
 
         with mock.patch.object(
-            # Mock _create_preconditioned_dims_selector_list() to enable the instantiation of BaseShampooPreconditionerList.
+            # Mock _create_preconditioned_dims_selector() to enable the instantiation of BaseShampooPreconditionerList.
             BaseShampooPreconditionerList,
-            "_create_preconditioned_dims_selector_list",
-            return_value=((True,) * max(param.dim(), 1),),
-        ) as mock_create_preconditioned_dims_selector_list, mock.patch.object(
+            "_create_preconditioned_dims_selector",
+            return_value=(True,) * max(param.dim(), 1),
+        ) as mock_create_preconditioned_dims_selector, mock.patch.object(
             # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
             BaseShampooPreconditionerList,
             "_update_factor_matrices",
@@ -308,7 +308,7 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
                 perform_amortized_computation=True,
             )
 
-            mock_create_preconditioned_dims_selector_list.assert_called_once()
+            mock_create_preconditioned_dims_selector.assert_called_once()
             mock_update_factor_matrices.assert_called_once()
 
 


### PR DESCRIPTION
Summary:
This diff fixes the statistics initializations of eigendecompose Shampoo and eigenvalue-corrected Shampoo. For eigendecompose Shampoo, this changes include initializing the eigenvectors matrices as identity matrices and initializing the eigenvalues as all ones. For eigenvalue-corrected Shampoo, this changes include initializing the eigenvectors matcies as identity matrices, and keeping corrected eigenvalues as all 0s.

Extend `distributed_state_dict()`-related tests to include testing eigendecompose Shampoo and eigenvalue-corrected Shampoo to verify the initializations.

Differential Revision: D72093421


