### PR TITLE
Leverage `torch.isfinite()` to simplify `torch.isnan()` and `torch.isinf()` checks

### DIFF
--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -1328,10 +1328,7 @@ class EigendecomposedShampooPreconditionerList(
                         (factor_matrix_eigenvalues, factor_matrix_eigenvectors),
                         strict=True,
                     ):
-                        if (
-                            torch.isnan(computed_quantity).any()
-                            or torch.isinf(computed_quantity).any()
-                        ):
+                        if not torch.isfinite(computed_quantity).all():
                             torch.set_printoptions(threshold=100_000)
                             raise PreconditionerValueError(
                                 f"Encountered nan or inf values in {quantity_name} of factor matrix {factor_matrix_index}! "

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -666,7 +666,7 @@ def _matrix_inverse_root_higher_order(
         # If we have inf/nan in our answer also raise an arithmetic exception.
         # Usually, this is due to the powering to q > 1 which can blow up entries.
         # We have not seen this yet for q = 1 in Shampoo.
-        if torch.isnan(X).any() or torch.isinf(X).any():
+        if not torch.isfinite(X).all():
             raise ArithmeticError(
                 "NaN/Inf in matrix inverse root (after powering for fractions), raising an exception!"
             )


### PR DESCRIPTION
Summary: Inspired by https://github.com/facebookresearch/optimizers/issues/99, `torch.isfinite()` is equal to `not torch.isnan() and not torch.isinf()`.

Co-Authored-By: @namgyu-youn <yynk2012@gmail.com>

Differential Revision: D72099932


