### PR TITLE
Add Adam into workflow as a baseline

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -19,6 +19,10 @@ jobs:
           run: |
             uv venv && source .venv/bin/activate
             uv pip install ".[examples]"
+        - name: Run default example with Adam to serve as a baseline.
+          run: |
+            source .venv/bin/activate
+            CUDA_VISIBLE_DEVICES="" python -m distributed_shampoo.examples.default_cifar10_example --optimizer-type ADAM
         - name: Run default example on CPU.
           run: |
             source .venv/bin/activate


### PR DESCRIPTION
Summary: To help the investigations of Shampoo loss on CIFAR10 examples are exploding in the OSS side, we want to use Adam as a baseline to verify either the model side or Shampoo side is having issues.

Differential Revision: D72116565


