### PR TITLE
Remove `is_factor_matrices_diagonal`

### DIFF
--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -264,7 +264,7 @@ class DistributedShampooStateDictTest(unittest.TestCase):
             lr=0.01,
             betas=(0.9, 1.0),
             epsilon=1e-12,
-            momentum=0.0,
+            momentum=0.9,
             weight_decay=0.0,
             max_preconditioner_dim=5,
             precondition_frequency=1,
@@ -380,6 +380,24 @@ class DistributedShampooStateDictTest(unittest.TestCase):
                             [0.0, 0.0, 0.0, 0.0, 0.0],
                         ]
                     ),
+                    '["block_0", "momentum"]': torch.tensor(
+                        [
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                        ]
+                    ),
+                    '["block_1", "momentum"]': torch.tensor(
+                        [
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                        ]
+                    ),
                     '["block_0", "filtered_grad"]': torch.tensor(
                         [
                             [0.0, 0.0, 0.0, 0.0, 0.0],
@@ -406,7 +424,7 @@ class DistributedShampooStateDictTest(unittest.TestCase):
                     "betas": (0.9, 1.0),
                     "beta3": 0.9,
                     "epsilon": 1e-12,
-                    "momentum": 0.0,
+                    "momentum": 0.9,
                     "dampening": 0.0,
                     "weight_decay": 0.0,
                     "max_preconditioner_dim": 5,

--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -228,12 +228,6 @@ class AbstractTest:
                         device_mesh=DeviceMesh(str(self._device), [1]),
                         placements=(Replicate(),),
                     ),
-                    '["block_1", "shampoo", "is_factor_matrices_diagonal", 0]': tensor(
-                        False
-                    ),
-                    '["block_1", "shampoo", "is_factor_matrices_diagonal", 1]': tensor(
-                        False
-                    ),
                     '["block_1", "shampoo", "inv_factor_matrices", 0]': DTensor.from_local(
                         local_tensor=tensor(
                             [
@@ -313,12 +307,6 @@ class AbstractTest:
                         ),
                         device_mesh=DeviceMesh(str(self._device), [0]),
                         placements=(Replicate(),),
-                    ),
-                    '["block_0", "shampoo", "is_factor_matrices_diagonal", 0]': tensor(
-                        False
-                    ),
-                    '["block_0", "shampoo", "is_factor_matrices_diagonal", 1]': tensor(
-                        False
                     ),
                     '["block_0", "shampoo", "inv_factor_matrices", 0]': DTensor.from_local(
                         local_tensor=tensor(


### PR DESCRIPTION
Summary:
The diagonal factor matrix field has been identified as unnecessary in practice. After the initial training step, the factor matrix rapidly becomes non-diagonal and remains so for its entire lifespan. Furthermore, our test setups, which primarily rely on diagonal factor matrices combined with optimized diagonal matrix functions, may not detect bugs or misconfigurations when using the diagonal matrix version of these functions.

To simplify the codebase and eliminate potential issues, this diff removes the diagonal factor matrix field.

Differential Revision: D72259390


