### PR TITLE
Leverage `operator.methodcaller()` to simplify code

### DIFF
--- a/commons.py
+++ b/commons.py
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import reduce
-from operator import or_
+from operator import methodcaller, or_
 from typing import Any, TypeVar
 
 
@@ -80,9 +80,10 @@ def get_all_subclasses(
 
     def get_all_unique_subclasses(cls: SubclassesType) -> set[SubclassesType]:
         """Gets all unique subclasses of a given class recursively."""
-        assert (
-            subclasses := getattr(cls, "__subclasses__", lambda: None)()
-        ) is not None, f"{cls} does not have __subclasses__."
-        return reduce(or_, map(get_all_unique_subclasses, subclasses), {cls})
+        return reduce(
+            or_,
+            map(get_all_unique_subclasses, methodcaller("__subclasses__")(cls)),
+            {cls},
+        )
 
     return list(get_all_unique_subclasses(cls) - (set() if include_cls_self else {cls}))

--- a/tests/commons_test.py
+++ b/tests/commons_test.py
@@ -106,14 +106,3 @@ class GetAllSubclassesTest(unittest.TestCase):
                     ),
                     [DummyLeafClass] if include_cls_self else [],
                 )
-
-    def test_assertion_error(self) -> None:
-        """Test error handling for non-class objects."""
-        for obj in (42, "string", DummyRootClass()):
-            with self.subTest(obj=obj):
-                self.assertRaisesRegex(
-                    AssertionError,
-                    f"{obj} does not have __subclasses__.",
-                    get_all_subclasses,
-                    obj,
-                )


### PR DESCRIPTION
Summary: This diff simplifies the code in the `commons.py` file by using `operator.methodcaller()` to call the `__subclasses__` method of a given class. This allows for cleaner and more concise code due to no linter complains.

Differential Revision: D72293265


