### PR TITLE
Fix mismatch dtypes when using QR algorithm

### DIFF
--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -1257,9 +1257,10 @@ class EigendecomposedShampooPreconditionerList(
                     if isinstance(
                         eigendecomposition_config, QREigendecompositionConfig
                     ):
+                        # Due to the use of QR algorithm, we need to pass in the previous eigenvectors with the same dtype as the input matrix, i.e., bias_corrected_factor_matrix.
                         eigendecomposition_config.eigenvectors_estimate = (
                             factor_matrix_eigenvectors
-                        )
+                        ).to(dtype=bias_corrected_factor_matrix.dtype)
                     try:
                         computed_eigenvalues, computed_eigenvectors = (
                             matrix_eigendecomposition(
@@ -1268,6 +1269,8 @@ class EigendecomposedShampooPreconditionerList(
                                 is_diagonal=False,
                             )
                         )
+                        computed_eigenvalues.to(dtype=factor_matrix_eigenvalues.dtype)
+                        computed_eigenvectors.to(dtype=factor_matrix_eigenvectors.dtype)
                         # Add success to success tracker.
                         success_tracker.append(True)
                     except Exception as exception:
@@ -1551,15 +1554,16 @@ class EigenvalueCorrectedShampooPreconditionerList(
                     if isinstance(
                         eigendecomposition_config, QREigendecompositionConfig
                     ):
+                        # Due to the use of QR algorithm, we need to pass in the previous eigenvectors with the same dtype as the input matrix, i.e., factor_matrix.
                         eigendecomposition_config.eigenvectors_estimate = (
                             factor_matrix_eigenvectors
-                        )
+                        ).to(dtype=factor_matrix.dtype)
                     try:
                         computed_eigenvectors = matrix_eigendecomposition(
                             A=factor_matrix,
                             eigendecomposition_config=eigendecomposition_config,
                             is_diagonal=False,
-                        )[1]
+                        )[1].to(dtype=factor_matrix_eigenvectors.dtype)
                         # Add success to success tracker.
                         success_tracker.append(True)
                     except Exception as exception:

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -278,11 +278,11 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
         BaseShampooPreconditionerList.__abstractmethods__ = frozenset()
 
         with mock.patch.object(
-            # Mock _create_preconditioned_dims_selector_list() to enable the instantiation of BaseShampooPreconditionerList.
+            # Mock _create_preconditioned_dims_selector() to enable the instantiation of BaseShampooPreconditionerList.
             BaseShampooPreconditionerList,
-            "_create_preconditioned_dims_selector_list",
-            return_value=((True,) * max(param.dim(), 1),),
-        ) as mock_create_preconditioned_dims_selector_list, mock.patch.object(
+            "_create_preconditioned_dims_selector",
+            return_value=(True,) * max(param.dim(), 1),
+        ) as mock_create_preconditioned_dims_selector, mock.patch.object(
             # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
             BaseShampooPreconditionerList,
             "_update_factor_matrices",
@@ -308,7 +308,7 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
                 perform_amortized_computation=True,
             )
 
-            mock_create_preconditioned_dims_selector_list.assert_called_once()
+            mock_create_preconditioned_dims_selector.assert_called_once()
             mock_update_factor_matrices.assert_called_once()
 
 


### PR DESCRIPTION
Summary:
This diff addresses a potential type mismatch issue between `factor_matrices` and `factor_matrix_eigenvectors` in the QR algorithm. It also ensures consistent output type conversions for eigendecomposed Shampoo and eigenvalue-corrected Shampoo.
- Convert `factor_matrix_eigenvectors` to match the type of `factor_matrices` before applying the QR algorithm.
- Update output type conversions for eigendecomposed Shampoo and eigenvalue-corrected Shampoo to align with Shampoo.

Prevents errors caused by type mismatches in the QR algorithm and ensures consistency in output type conversions across different Shampoo variants.

Reviewed By: anana10c

Differential Revision: D72334952
