### PR TITLE
Improve test coverage for `_create_preconditioned_dims_selector()`

### DIFF
--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -278,16 +278,16 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
         BaseShampooPreconditionerList.__abstractmethods__ = frozenset()
 
         with mock.patch.object(
-            # Mock _create_preconditioned_dims_selector() to enable the instantiation of BaseShampooPreconditionerList.
-            BaseShampooPreconditionerList,
-            "_create_preconditioned_dims_selector",
+            # Mock compress_list() to enable the instantiation of BaseShampooPreconditionerList.
+            shampoo_preconditioner_list,
+            "compress_list",
             return_value=(True,) * max(param.dim(), 1),
-        ) as mock_create_preconditioned_dims_selector, mock.patch.object(
+        ) as mock_compress_list, mock.patch.object(
             # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
             BaseShampooPreconditionerList,
             "_update_factor_matrices",
         ) as mock_update_factor_matrices:
-            # Test the abstract methods _create_kronecker_factors_state_for_block(), _create_kronecker_factors_list(), and _get_inverse_roots_from_override().
+            # Test the abstract methods _create_preconditioned_dims_selector(), _create_kronecker_factors_state_for_block(), _create_kronecker_factors_list(), and _get_inverse_roots_from_override().
             preconditioner_list = BaseShampooPreconditionerList(  # type: ignore
                 block_list=(param,),
                 state={param: {}},
@@ -308,7 +308,7 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
                 perform_amortized_computation=True,
             )
 
-            mock_create_preconditioned_dims_selector.assert_called_once()
+            mock_compress_list.assert_called_once()
             mock_update_factor_matrices.assert_called_once()
 
 

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -278,11 +278,11 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
         BaseShampooPreconditionerList.__abstractmethods__ = frozenset()
 
         with mock.patch.object(
-            # Mock _create_preconditioned_dims_selector_list() to enable the instantiation of BaseShampooPreconditionerList.
+            # Mock _create_preconditioned_dims_selector() to enable the instantiation of BaseShampooPreconditionerList.
             BaseShampooPreconditionerList,
-            "_create_preconditioned_dims_selector_list",
-            return_value=((True,) * max(param.dim(), 1),),
-        ) as mock_create_preconditioned_dims_selector_list, mock.patch.object(
+            "_create_preconditioned_dims_selector",
+            return_value=(True,) * max(param.dim(), 1),
+        ) as mock_create_preconditioned_dims_selector, mock.patch.object(
             # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
             BaseShampooPreconditionerList,
             "_update_factor_matrices",
@@ -308,7 +308,7 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
                 perform_amortized_computation=True,
             )
 
-            mock_create_preconditioned_dims_selector_list.assert_called_once()
+            mock_create_preconditioned_dims_selector.assert_called_once()
             mock_update_factor_matrices.assert_called_once()
 
 


### PR DESCRIPTION
Summary: Instead of mocking `_create_preconditioned_dims_selector()`, this diff mocks `compress_list()` to enable the test of `BaseShampooPreconditionerList._create_preconditioned_dims_selector()`.

Differential Revision: D72435714


