### PR TITLE
Assign a default value of `DDPBlockInfo.get_tensor()`

### DIFF
--- a/distributed_shampoo/utils/shampoo_ddp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_ddp_distributor.py
@@ -222,11 +222,6 @@ class DDPDistributor(DistributorInterface):
                     self._allocate_zeros_distributed_tensor,
                     group_source_rank=group_source_rank,
                 ),
-                get_tensor=lambda input_tensor: (
-                    input_tensor.to_local()
-                    if isinstance(input_tensor, dtensor.DTensor)
-                    else input_tensor
-                ),
                 group_source_rank=group_source_rank,
             )
             for (

--- a/distributed_shampoo/utils/shampoo_hsdp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hsdp_distributor.py
@@ -339,11 +339,6 @@ class HSDPDistributor(DistributorInterface):
                     self._allocate_zeros_distributed_tensor,
                     group_source_rank=group_source_rank,
                 ),
-                get_tensor=lambda input_tensor: (
-                    input_tensor.to_local()
-                    if isinstance(input_tensor, dtensor.DTensor)
-                    else input_tensor
-                ),
                 group_source_rank=group_source_rank,
             )
             for (

--- a/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
@@ -350,11 +350,6 @@ class HybridShardDistributor(DistributorInterface):
                     self._allocate_zeros_distributed_tensor,
                     group_source_rank=group_source_rank,
                 ),
-                get_tensor=lambda input_tensor: (
-                    input_tensor.to_local()
-                    if isinstance(input_tensor, dtensor.DTensor)
-                    else input_tensor
-                ),
                 group_source_rank=group_source_rank,
             )
             for (


### PR DESCRIPTION
Summary: 
1. Reduces the boilerplate codes duplications.
2. Tighten `get_tensor()` so it is not able to initialize because the default value.

Differential Revision: D72476847


