### PR TITLE
Relax the type constraints of `ShampooPreconditionerConfig.inverse_exponent_override`

### DIFF
--- a/distributed_shampoo/shampoo_types.py
+++ b/distributed_shampoo/shampoo_types.py
@@ -107,7 +107,7 @@ class ShampooPreconditionerConfig(PreconditionerConfig):
         amortized_computation_config (RootInvConfig | EigendecompositionConfig): Configuration for the inverse-root computation. (Default: DefaultEigenConfig)
         num_tolerated_failed_amortized_computations (int): Number of failed amortized computations to tolerate before raising an error. (Default: 3)
         inverse_exponent_override (dict[int, dict[int, float]]): The inverse_exponent_override attribute is a dictionary that allows for customizing the inverse exponent used in the Shampoo preconditioner computation.
-            The keys of the dictionary represent the order of the tensor, and the values are dictionaries with dimension indices as keys and override values as values. All unspecified dimensions use a default exponent of 1/(2*o), where o is the order of the tensor. (Default: {})
+            The keys of the dictionary represent the order of the tensor, and the values are dictionaries with dimension indices as keys and override values as values. All unspecified dimensions use a default exponent of 1/(2*max(o,1)), where o is the order of the tensor. (Default: {})
 
             As an example, suppose inverse_exponent_override={2: {0: 0.5, 1: 0.2}, 3: {0: 0.0, 1: 0.25}}. In this case, all 1-D tensors will use the default exponent of 0.5 for preconditioning the first (and only) dimension. All 2-D tensors will be preconditioned with an exponent of 0.5 on the first dimension and 0.2 on the second dimension. All 3-D tensors will have the first dimension be preconditioned with an exponent of 0.5, the second dimension not preconditioned, and the third dimension preconditioned with the default exponent 0.1667.
             A visualization of this example can be seen below:

--- a/distributed_shampoo/tests/shampoo_types_test.py
+++ b/distributed_shampoo/tests/shampoo_types_test.py
@@ -81,12 +81,13 @@ class PreconditionerConfigSubclassesTest(unittest.TestCase):
 @instantiate_parametrized_tests
 class ShampooPreconditionerConfigSubclassesTest(unittest.TestCase):
     @parametrize(  # type: ignore
-        "cls", get_all_subclasses(ShampooPreconditionerConfig, include_cls_self=True)
+        "cls",
+        get_all_subclasses(ShampooPreconditionerConfig, include_cls_self=True),
     )
     def test_illegal_inverse_exponent_override(
         self, cls: type[ShampooPreconditionerConfig]
     ) -> None:
-        non_positive_orders_config: dict[int, dict[int, float]] = {
+        non_positive_orders_config: dict[int, dict[int, float] | float] = {
             -1: {},
             -2: {},
         }
@@ -100,31 +101,44 @@ class ShampooPreconditionerConfigSubclassesTest(unittest.TestCase):
         )
 
         # illegal_dimensions_config[1] is the problematic one.
-        illegal_dimensions_config: dict[int, dict[int, float]] = {
-            0: {0: 0.2},
+        illegal_dimensions_config: dict[int, dict[int, float] | float] = {
+            0: 0.2,
             1: {0: 0.3, 1: 0.2},
         }
         self.assertRaisesRegex(
             ValueError,
             re.escape(
-                f"Invalid dimensions in self.inverse_exponent_override[order]={illegal_dimensions_config[1]}: [1]. All dimensions must be within [0, 0]."
+                f"Invalid dimensions in self.inverse_exponent_override[1]={illegal_dimensions_config[1]}: [1]. All dimensions must be within [0, 0]."
             ),
             cls,
             inverse_exponent_override=illegal_dimensions_config,
         )
 
-        # non_positive_overrides_config[1] is the problematic one.
-        non_positive_overrides_config: dict[int, dict[int, float]] = {
+        # non_positive_dim_overrides_config[1] is the problematic one.
+        non_positive_dim_overrides_config: dict[int, dict[int, float] | float] = {
             1: {0: -0.3},
-            2: {0: 0.2, 1: 0.5},
+            2: 0.2,
         }
         self.assertRaisesRegex(
             ValueError,
             re.escape(
-                f"Invalid override value in self.inverse_exponent_override[order]={non_positive_overrides_config[1]}: [-0.3]. All overrides must be >= 0."
+                f"Invalid override value in self.inverse_exponent_override[1]={non_positive_dim_overrides_config[1]}: [-0.3]. All overrides must be >= 0."
             ),
             cls,
-            inverse_exponent_override=non_positive_overrides_config,
+            inverse_exponent_override=non_positive_dim_overrides_config,
+        )
+
+        non_positive_universal_overrides_config: dict[int, dict[int, float] | float] = {
+            1: -0.2,
+            2: {0: 0.3, 1: 0.2},
+        }
+        self.assertRaisesRegex(
+            ValueError,
+            re.escape(
+                f"Invalid override value in self.inverse_exponent_override[1]={non_positive_universal_overrides_config[1]}: {non_positive_universal_overrides_config[1]}. All overrides must be >= 0."
+            ),
+            cls,
+            inverse_exponent_override=non_positive_universal_overrides_config,
         )
 
 

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -936,7 +936,7 @@ class ShampooPreconditionerList(
         return tuple(
             attrgetter(INVERSE_EXPONENT_OVERRIDE)(self._preconditioner_config)
             .get((order := len(dims)), {})
-            .get(d, 1 / (2 * order))
+            .get(d, 1 / (2 * max(order, 1)))
             != 0.0
             # Traverse through each dim of a block.
             for d in range(len(dims))
@@ -967,7 +967,7 @@ class ShampooPreconditionerList(
             1
             / attrgetter(INVERSE_EXPONENT_OVERRIDE)(self._preconditioner_config)
             .get((order := len(preconditioned_dims_selector)), {})
-            .get(k, 1 / (2 * order))
+            .get(k, 1 / (2 * max(order, 1)))
             # Traverse through each dim of a block that requires precondition.
             for k, should_precondition in enumerate(preconditioned_dims_selector)
             if should_precondition

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -956,7 +956,7 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
                     inverse_exponent_override={
                         0: {0: 0.0},
                         1: {0: 0.0},
-                        2: {0: 0.0, 1: 0.0},
+                        2: 0.0,
                     },
                 ),
             ),
@@ -1007,7 +1007,7 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
             inverse_exponent_override={
                 0: {0: 1.0},
                 1: {0: 1.0},
-                2: {0: 1.0, 1: 1.0},
+                2: 1.0,
             },
         )
 


### PR DESCRIPTION
Summary: Extend the supported type of `ShampooPreconditionerConfig.inverse_exponent_override` from `dict[int, dict[int, float]]` to `dict[int, dict[int, float] | float]` to save users' errands on specifying a universal override value for all dimensions under an order of a tensor.

This also factors out the common implementations of `ShampooPreconditionerList` and `EigendecomposedShampooPreconditionerList` to reduce the code duplications.

Differential Revision: D72614201


