### PR TITLE
Leverage PyTorch `parametrize` to simplify test

### DIFF
--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -39,8 +39,13 @@ from matrix_functions_types import (
     RootInvConfig,
 )
 from torch import nn
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 
+@instantiate_parametrized_tests
 class DistributedShampooInitTest(unittest.TestCase):
     def setUp(self) -> None:
         self._model = nn.Sequential(
@@ -95,10 +100,9 @@ class DistributedShampooInitTest(unittest.TestCase):
             grafting_config=NotSupportedGraftingConfig(),
         )
 
-    def test_invalid_with_incorrect_hyperparameter_setting(self) -> None:
-        incorrect_hyperparameter_setting_and_expected_error_msg: list[
-            tuple[dict[str, Any], str]
-        ] = [
+    @parametrize(
+        "incorrect_hyperparameter_setting, expected_error_msg",
+        [
             (
                 {"lr": -0.1},
                 "Invalid learning rate: -0.1. Must be >= 0.0.",
@@ -157,23 +161,18 @@ class DistributedShampooInitTest(unittest.TestCase):
                 },
                 "preconditioner_config.amortized_computation_config.exponent_multiplier is not supported. Please use PreconditionerConfig.inverse_exponent_override instead.",
             ),
-        ]
-
-        for (
-            incorrect_hyperparameter_setting,
-            expected_error_msg,
-        ) in incorrect_hyperparameter_setting_and_expected_error_msg:
-            with self.subTest(
-                incorrect_hyperparameter_setting=incorrect_hyperparameter_setting,
-                expected_error_msg=expected_error_msg,
-            ):
-                self.assertRaisesRegex(
-                    ValueError,
-                    re.escape(expected_error_msg),
-                    DistributedShampoo,
-                    self._model.parameters(),
-                    **incorrect_hyperparameter_setting,
-                )
+        ],
+    )
+    def test_invalid_with_incorrect_hyperparameter_setting(
+        self, incorrect_hyperparameter_setting: dict[str, Any], expected_error_msg: str
+    ) -> None:
+        self.assertRaisesRegex(
+            ValueError,
+            re.escape(expected_error_msg),
+            DistributedShampoo,
+            self._model.parameters(),
+            **incorrect_hyperparameter_setting,
+        )
 
     def test_nesterov_and_zero_momentum(self) -> None:
         with self.assertLogs(


### PR DESCRIPTION
Summary: This is the equivalent of popular [`pytest.mark.parametrize`](https://docs.pytest.org/en/stable/example/parametrize.html) in PyTorch. This is the first try on using this in this project.

Differential Revision: D72897224


