### PR TITLE
Leverage `parametrize` to simplify test

### DIFF
--- a/tests/commons_test.py
+++ b/tests/commons_test.py
@@ -13,27 +13,25 @@ import unittest
 from dataclasses import dataclass
 
 from commons import AbstractDataclass, get_all_subclasses
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 
-@dataclass(init=False)
-class DummyOptimizerConfig(AbstractDataclass):
-    """Dummy abstract dataclass for testing. Instantiation should fail."""
-
-
+@instantiate_parametrized_tests
 class InvalidAbstractDataclassInitTest(unittest.TestCase):
-    def test_invalid_init(self) -> None:
-        for abstract_cls in (
-            AbstractDataclass,
-            DummyOptimizerConfig,
-        ):
-            with self.subTest(abstract_cls=abstract_cls):
-                self.assertRaisesRegex(
-                    TypeError,
-                    re.escape(
-                        f"Can't instantiate abstract class {abstract_cls.__name__} "
-                    ),
-                    abstract_cls,
-                )
+    @dataclass(init=False)
+    class DummyOptimizerConfig(AbstractDataclass):
+        """Dummy abstract dataclass for testing. Instantiation should fail."""
+
+    @parametrize("abstract_cls", (AbstractDataclass, DummyOptimizerConfig))
+    def test_invalid_init(self, abstract_cls: type[AbstractDataclass]) -> None:
+        self.assertRaisesRegex(
+            TypeError,
+            re.escape(f"Can't instantiate abstract class {abstract_cls.__name__} "),
+            abstract_cls,
+        )
 
 
 class DummyRootClass:
@@ -60,49 +58,34 @@ class DummyLeafClass(DummyMixedSubclass):
     """Dummy leaf class for GetAllSubclassesTest."""
 
 
+@instantiate_parametrized_tests
 class GetAllSubclassesTest(unittest.TestCase):
-    def test_get_all_subclasses(self) -> None:
-        """Test with class hierarchy and multiple inheritance."""
-        for include_cls_self in (True, False):
-            with self.subTest(
-                "Test with the root class", include_cls_self=include_cls_self
-            ):
-                subclasses = {
-                    DummyFirstSubclass,
-                    DummySecondSubclass,
-                    DummyMixedSubclass,
-                    DummyLeafClass,
-                }
-                self.assertEqual(
-                    set(
-                        get_all_subclasses(
-                            DummyRootClass, include_cls_self=include_cls_self
-                        )
-                    ),
-                    {DummyRootClass} | subclasses if include_cls_self else subclasses,
-                )
-            with self.subTest(
-                "Test with the second subclass (parents should not be included)",
-                include_cls_self=include_cls_self,
-            ):
-                subclasses = {DummyMixedSubclass, DummyLeafClass}
-                self.assertEqual(
-                    set(
-                        get_all_subclasses(
-                            DummySecondSubclass, include_cls_self=include_cls_self
-                        )
-                    ),
-                    {DummySecondSubclass} | subclasses
-                    if include_cls_self
-                    else subclasses,
-                )
-            with self.subTest(
-                "Test with leaf class (no subclasses)",
-                include_cls_self=include_cls_self,
-            ):
-                self.assertEqual(
-                    get_all_subclasses(
-                        DummyLeafClass, include_cls_self=include_cls_self
-                    ),
-                    [DummyLeafClass] if include_cls_self else [],
-                )
+    @parametrize("include_cls_self", (True, False))
+    def test_class_hierarchy_and_multiple_inheritance(
+        self, include_cls_self: bool
+    ) -> None:
+        subclasses = [
+            DummyFirstSubclass,
+            DummySecondSubclass,
+            DummyMixedSubclass,
+            DummyLeafClass,
+        ]
+        self.assertCountEqual(
+            get_all_subclasses(DummyRootClass, include_cls_self=include_cls_self),
+            subclasses + [DummyRootClass] * include_cls_self,
+        )
+
+    @parametrize("include_cls_self", (True, False))
+    def test_second_subclass(self, include_cls_self: bool) -> None:
+        subclasses = [DummyMixedSubclass, DummyLeafClass]
+        self.assertCountEqual(
+            get_all_subclasses(DummySecondSubclass, include_cls_self=include_cls_self),
+            subclasses + [DummySecondSubclass] * include_cls_self,
+        )
+
+    @parametrize("include_cls_self", (True, False))
+    def test_leaf_class(self, include_cls_self: bool) -> None:
+        self.assertCountEqual(
+            get_all_subclasses(DummyLeafClass, include_cls_self=include_cls_self),
+            [DummyLeafClass] * include_cls_self,
+        )


### PR DESCRIPTION
Summary: This diff simplifies the test for `commons_test.py` by using `parametrize` from `torch.testing._internal.common_utils`. This allows for more efficient testing and reduces the amount of code needed to be written.

Differential Revision: D73014632


