### PR TITLE
Leverage Structural Pattern Matching to refactor

### DIFF
--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -16,10 +16,8 @@ import unittest
 from dataclasses import dataclass
 from itertools import chain
 from typing import Any
-from unittest import mock
 
 import torch
-from distributed_shampoo import distributed_shampoo
 from distributed_shampoo.distributed_shampoo import DistributedShampoo
 from distributed_shampoo.shampoo_types import (
     AdaGradGraftingConfig,
@@ -31,12 +29,7 @@ from distributed_shampoo.shampoo_types import (
     PreconditionerConfig,
     ShampooPreconditionerConfig,
 )
-from matrix_functions_types import (
-    DefaultEigendecompositionConfig,
-    EigenConfig,
-    EigendecompositionConfig,
-    RootInvConfig,
-)
+from matrix_functions_types import DefaultEigendecompositionConfig, EigenConfig
 from torch import nn
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -65,23 +58,6 @@ class DistributedShampooInitTest(unittest.TestCase):
                 amortized_computation_config=DefaultEigendecompositionConfig
             ),
         )
-
-        with mock.patch.object(
-            distributed_shampoo,
-            "isinstance",
-            side_effect=lambda object, classinfo: False
-            if classinfo in (RootInvConfig, EigendecompositionConfig)
-            else None,
-        ):
-            self.assertRaisesRegex(
-                NotImplementedError,
-                re.escape(
-                    "group[PRECONDITIONER_CONFIG].amortized_computation_config=EigenConfig(retry_double_precision=True, eigendecomposition_offload_device='', exponent_multiplier=1.0, enhance_stability=False) not supported!"
-                ),
-                DistributedShampoo,
-                self._model.parameters(),
-                preconditioner_config=DefaultShampooConfig,
-            )
 
     def test_invalid_grafting_config(self) -> None:
         @dataclass

--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -428,6 +428,20 @@ class AbstractTest:
             else:
                 mock_step.assert_not_called()
 
+        def test_unsupported_communication_dtype(self) -> None:
+            self._init_distributed()
+
+            with mock.patch.object(CommunicationDType, "__eq__", return_value=False):
+                self.assertRaisesRegex(
+                    NotImplementedError,
+                    re.escape(
+                        "Unsupported communication dtype: CommunicationDType.DEFAULT"
+                    ),
+                    AbstractTest.ShampooDDPDistributorDeviceTest._train_model,
+                    self._shampoo_optim_factory(distributed_config=DDPShampooConfig()),
+                    device=self._device,
+                )
+
 
 class ShampooDDPDistributorCPUTest(AbstractTest.ShampooDDPDistributorDeviceTest):
     @property

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -347,3 +347,25 @@ class ShampooHSDPDistributorTest(FSDPTest):
                 model_factory=ShampooHSDPDistributorTest._model_factory(hsdp_config),
                 device=torch.device("cuda"),
             )
+
+    @skip_if_lt_x_gpu(4)
+    def test_unsupported_communication_dtype(self) -> None:
+        mesh_2d = init_device_mesh("cuda", (2, 2))
+        hsdp_config = HSDPShampooConfig(
+            param_to_metadata={},
+            device_mesh=mesh_2d,
+        )
+
+        with mock.patch.object(CommunicationDType, "__eq__", return_value=False):
+            self.assertRaisesRegex(
+                NotImplementedError,
+                re.escape(
+                    "Unsupported communication dtype: CommunicationDType.DEFAULT"
+                ),
+                ShampooHSDPDistributorTest._train_model,
+                optim_factory=ShampooHSDPDistributorTest._shampoo_optim_factory(
+                    distributed_config=hsdp_config,
+                ),
+                model_factory=ShampooHSDPDistributorTest._model_factory(hsdp_config),
+                device=torch.device("cuda"),
+            )

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
@@ -465,3 +465,28 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
                 ),
                 device=torch.device("cuda"),
             )
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    def test_unsupported_communication_dtype(self) -> None:
+        mesh_2d = init_device_mesh(
+            "cuda", (2, 2), mesh_dim_names=("replicate", "shard")
+        )
+        hybrid_shard_config = HybridShardShampooConfig(device_mesh=mesh_2d)
+
+        with mock.patch.object(CommunicationDType, "__eq__", return_value=False):
+            self.assertRaisesRegex(
+                NotImplementedError,
+                re.escape(
+                    "Unsupported communication dtype: CommunicationDType.DEFAULT"
+                ),
+                ShampooHybridShardDistributorTest._train_model,
+                optim_factory=ShampooHybridShardDistributorTest._shampoo_optim_factory(
+                    distributed_config=hybrid_shard_config,
+                ),
+                model_factory=ShampooHybridShardDistributorTest._model_factory(
+                    hybrid_shard_config,
+                    device_mesh=mesh_2d,
+                ),
+                device=torch.device("cuda"),
+            )

--- a/distributed_shampoo/utils/shampoo_ddp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_ddp_distributor.py
@@ -78,16 +78,17 @@ class DDPDistributor(DistributorInterface):
         self._communicate_params: bool = distributed_config.communicate_params
 
         # Determine communication type.
-        if distributed_config.communication_dtype == CommunicationDType.BF16:
-            communication_dtype = torch.bfloat16
-        elif distributed_config.communication_dtype == CommunicationDType.FP16:
-            communication_dtype = torch.float16
-        else:
-            assert distributed_config.communication_dtype in [
-                CommunicationDType.FP32,
-                CommunicationDType.DEFAULT,
-            ]
-            communication_dtype = torch.float32
+        match distributed_config.communication_dtype:
+            case CommunicationDType.BF16:
+                communication_dtype = torch.bfloat16
+            case CommunicationDType.FP16:
+                communication_dtype = torch.float16
+            case CommunicationDType.FP32 | CommunicationDType.DEFAULT:
+                communication_dtype = torch.float32
+            case _:
+                raise NotImplementedError(
+                    f"Unsupported communication dtype: {distributed_config.communication_dtype}"
+                )
 
         # Initialize _dist_group and _group_rank.
         self._dist_group: dist.ProcessGroup | None = (

--- a/distributed_shampoo/utils/shampoo_hsdp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hsdp_distributor.py
@@ -152,16 +152,17 @@ class HSDPDistributor(DistributorInterface):
         self._communicate_params: bool = distributed_config.communicate_params
 
         # Determine communication type.
-        if distributed_config.communication_dtype == CommunicationDType.BF16:
-            communication_dtype = torch.bfloat16
-        elif distributed_config.communication_dtype == CommunicationDType.FP16:
-            communication_dtype = torch.float16
-        else:
-            assert distributed_config.communication_dtype in [
-                CommunicationDType.FP32,
-                CommunicationDType.DEFAULT,
-            ]
-            communication_dtype = torch.float32
+        match distributed_config.communication_dtype:
+            case CommunicationDType.BF16:
+                communication_dtype = torch.bfloat16
+            case CommunicationDType.FP16:
+                communication_dtype = torch.float16
+            case CommunicationDType.FP32 | CommunicationDType.DEFAULT:
+                communication_dtype = torch.float32
+            case _:
+                raise NotImplementedError(
+                    f"Unsupported communication dtype: {distributed_config.communication_dtype}"
+                )
 
         # Initialize _dist_group and _group_rank.
         # Note that this requires initializing all process groups.

--- a/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
@@ -138,16 +138,17 @@ class HybridShardDistributor(DistributorInterface):
         self._communicate_params: bool = distributed_config.communicate_params
 
         # Determine communication type.
-        if distributed_config.communication_dtype == CommunicationDType.BF16:
-            communication_dtype = torch.bfloat16
-        elif distributed_config.communication_dtype == CommunicationDType.FP16:
-            communication_dtype = torch.float16
-        else:
-            assert distributed_config.communication_dtype in [
-                CommunicationDType.FP32,
-                CommunicationDType.DEFAULT,
-            ]
-            communication_dtype = torch.float32
+        match distributed_config.communication_dtype:
+            case CommunicationDType.BF16:
+                communication_dtype = torch.bfloat16
+            case CommunicationDType.FP16:
+                communication_dtype = torch.float16
+            case CommunicationDType.FP32 | CommunicationDType.DEFAULT:
+                communication_dtype = torch.float32
+            case _:
+                raise NotImplementedError(
+                    f"Unsupported communication dtype: {distributed_config.communication_dtype}"
+                )
 
         # Initialize _dist_group and _group_rank.
         # Note that this requires initializing all process groups.

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -277,19 +277,16 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
         # Disable the abstract methods check from the interface so it is possible to instantiate BaseShampooPreconditionerList.
         BaseShampooPreconditionerList.__abstractmethods__ = frozenset()
 
-        with (
-            mock.patch.object(
-                # Mock compress_list() to enable the instantiation of BaseShampooPreconditionerList.
-                shampoo_preconditioner_list,
-                "compress_list",
-                return_value=(True,) * max(param.dim(), 1),
-            ) as mock_compress_list,
-            mock.patch.object(
-                # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
-                BaseShampooPreconditionerList,
-                "_update_factor_matrices",
-            ) as mock_update_factor_matrices,
-        ):
+        with mock.patch.object(
+            # Mock compress_list() to enable the instantiation of BaseShampooPreconditionerList.
+            shampoo_preconditioner_list,
+            "compress_list",
+            return_value=(True,) * max(param.dim(), 1),
+        ) as mock_compress_list, mock.patch.object(
+            # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
+            BaseShampooPreconditionerList,
+            "_update_factor_matrices",
+        ) as mock_update_factor_matrices:
             # Test the abstract methods _create_preconditioned_dims_selector(), _create_kronecker_factors_state_for_block(), _create_kronecker_factors_list(), and _get_inverse_roots_from_override().
             preconditioner_list = BaseShampooPreconditionerList(  # type: ignore
                 block_list=(param,),


### PR DESCRIPTION
Summary: [Structural Pattern Matching](https://peps.python.org/pep-0636/) gives us the ability to refine previous patterns of `if ... elif ... elif ... else ...` into more structure codes. Especially the one with multiple levels matchings before, now it could be refactored into a single level matching (check `group[PRECONDITIONER_CONFIG]` initialization part in `distributed_shampoo.py`).

Differential Revision: D73017116


