### PR TITLE
Leverage `parametrize` to simplify tests

### DIFF
--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -9,14 +9,10 @@ LICENSE file in the root directory of this source tree.
 
 #!/usr/bin/env python3
 
-import abc
 import contextlib
 import re
-import unittest
-
 from collections.abc import Callable
 from functools import partial
-from itertools import product
 from unittest import mock
 
 import torch
@@ -25,6 +21,10 @@ from distributed_shampoo.shampoo_types import (
     AdaGradGraftingConfig,
     CommunicationDType,
     DDPShampooConfig,
+    DefaultEigenvalueCorrectedShampooConfig,
+    DefaultShampooConfig,
+    DefaultSOAPConfig,
+    PreconditionerConfig,
 )
 from distributed_shampoo.tests.shampoo_test_utils import (
     compare_two_optimizers_on_weight_and_loss,
@@ -37,420 +37,420 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate
 from torch.optim.optimizer import ParamsT
 from torch.testing._comparison import default_tolerances
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     DynamoDistributedMultiProcTestCase,
 )
+from torch.testing._internal.common_utils import parametrize
 
 
 PRECONDITIONER_DIM = 3
 
 
-# Use outer class as wrapper to avoid running the abstract test.
-class AbstractTest:
-    class ShampooDDPDistributorDeviceTest(abc.ABC, DynamoDistributedMultiProcTestCase):
-        @property
-        @abc.abstractmethod
-        def _device(self) -> torch.device: ...
+class ShampooDDPDistributorDeviceTest(DynamoDistributedMultiProcTestCase):
+    def _train_model(
+        self,
+        optim_factory: Callable[
+            [ParamsT],
+            torch.optim.Optimizer,
+        ],
+        device: torch.device,
+        model_linear_layers_dims: tuple[int, ...] = (
+            PRECONDITIONER_DIM * 4,
+            PRECONDITIONER_DIM * 2,
+            1,
+        ),
+        model_dead_layer_dims: tuple[int, ...] | None = (
+            PRECONDITIONER_DIM,
+            PRECONDITIONER_DIM,
+        ),
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        model, loss, data, target = construct_training_problem(
+            model_linear_layers_dims=model_linear_layers_dims,
+            model_dead_layer_dims=model_dead_layer_dims,
+            device=device,
+            fill=0.01,
+        )
+        params = list(model.parameters())
+        optimizer = optim_factory(params)
+        for _ in range(5):
+            optimizer.zero_grad()
+            objective = loss(model(data), target)
+            objective.backward()
+            optimizer.step()
+        return params[0], objective.detach()
 
-        @staticmethod
-        def _train_model(
-            optim_factory: Callable[
-                [ParamsT],
-                torch.optim.Optimizer,
-            ],
-            device: torch.device,
-            model_linear_layers_dims: tuple[int, ...] = (
+    def _init_distributed(self, device: str) -> None:
+        if not dist.is_initialized():
+            dist.init_process_group(
+                dist.Backend.NCCL if device == "cuda" else dist.Backend.GLOO,
+                init_method=f"file://{self.file_name}",
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+        if device == "cuda":
+            torch.cuda.set_device(self.rank)
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _shampoo_optim_factory(
+        self,
+        distributed_config: DDPShampooConfig | None,
+        preconditioner_config: PreconditionerConfig = DefaultShampooConfig,
+    ) -> Callable[[ParamsT], torch.optim.Optimizer]:
+        return partial(
+            DistributedShampoo,
+            lr=0.001,
+            betas=(0.9, 1.0),
+            epsilon=1e-8,
+            momentum=0.9,
+            weight_decay=0.0,
+            max_preconditioner_dim=PRECONDITIONER_DIM,
+            precondition_frequency=1,
+            start_preconditioning_step=2,
+            use_decoupled_weight_decay=True,
+            grafting_config=AdaGradGraftingConfig(
+                epsilon=1e-8,
+            ),
+            distributed_config=distributed_config,
+            preconditioner_config=preconditioner_config,
+        )
+
+    @parametrize(
+        "preconditioner_config",
+        (
+            DefaultShampooConfig,
+            DefaultEigenvalueCorrectedShampooConfig,
+            DefaultSOAPConfig,
+        ),
+    )
+    @parametrize(
+        "communication_dtype, communicate_params, rtol, atol",
+        (
+            # Expecting CommunicationDType.DEFAULT would have bitwise identical results (by setting rtol=atol=0.0).
+            (CommunicationDType.DEFAULT, False, 0.0, 0.0),
+            (CommunicationDType.DEFAULT, True, 0.0, 0.0),
+            # Using FP16 for distributed parameters prohibitively lowers precision.
+            (
+                CommunicationDType.FP16,
+                False,
+                *default_tolerances(torch.float16),
+            ),
+            (
+                CommunicationDType.BF16,
+                False,
+                # BF16 requires 2x tolerances than the original bfloat16 tolerances.
+                *[2 * tol for tol in default_tolerances(torch.bfloat16)],
+            ),
+        ),
+    )
+    @parametrize("num_trainers_per_group", (-1, 1, 2))
+    def test_losses(
+        self,
+        device: str,
+        num_trainers_per_group: int,
+        communication_dtype: CommunicationDType,
+        communicate_params: bool,
+        rtol: float,
+        atol: float,
+        preconditioner_config: PreconditionerConfig,
+    ) -> None:
+        self._init_distributed(device=device)
+
+        compare_two_optimizers_on_weight_and_loss(
+            control_optim_factory=self._shampoo_optim_factory(
+                distributed_config=None,
+                preconditioner_config=preconditioner_config,
+            ),
+            experimental_optim_factory=self._shampoo_optim_factory(
+                distributed_config=DDPShampooConfig(
+                    communication_dtype=communication_dtype,
+                    num_trainers_per_group=num_trainers_per_group,
+                    communicate_params=communicate_params,
+                ),
+                preconditioner_config=preconditioner_config,
+            ),
+            model_linear_layers_dims=(
                 PRECONDITIONER_DIM * 4,
                 PRECONDITIONER_DIM * 2,
                 1,
             ),
-            model_dead_layer_dims: tuple[int, ...] | None = (
-                PRECONDITIONER_DIM,
-                PRECONDITIONER_DIM,
-            ),
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            model, loss, data, target = construct_training_problem(
-                model_linear_layers_dims=model_linear_layers_dims,
-                model_dead_layer_dims=model_dead_layer_dims,
-                device=device,
-                fill=0.01,
-            )
-            params = list(model.parameters())
-            optimizer = optim_factory(params)
-            for _ in range(5):
-                optimizer.zero_grad()
-                objective = loss(model(data), target)
-                objective.backward()
-                optimizer.step()
-            return params[0], objective.detach()
+            model_dead_layer_dims=(PRECONDITIONER_DIM, PRECONDITIONER_DIM),
+            device=torch.device(device),
+            fill=0.01,
+            rtol=rtol,
+            atol=atol,
+        )
 
-        def _init_distributed(self) -> None:
-            if not dist.is_initialized():
-                dist.init_process_group(
-                    dist.Backend.NCCL
-                    if self._device == torch.device("cuda")
-                    else dist.Backend.GLOO,
-                    init_method=f"file://{self.file_name}",
-                    rank=self.rank,
-                    world_size=self.world_size,
-                )
-            if self._device == torch.device("cuda"):
-                torch.cuda.set_device(self.rank)
+    def test_distributed_state_dict(self, device: str) -> None:
+        self._init_distributed(device=device)
 
-        @property
-        def world_size(self) -> int:
-            return 2
+        model, loss, data, target = construct_training_problem(
+            # Setting model_linear_layers_dims to creates an model with one linear layer with (PRECONDITIONER_DIM * 2)xPRECONDITIONER_DIM weight.
+            # Because Shampoo's max_preconditioner_dim = PRECONDITIONER_DIM, there will be two blocks; rank 0 has block 0 and rank 1 has block 1.
+            model_linear_layers_dims=(PRECONDITIONER_DIM * 2, PRECONDITIONER_DIM),
+            model_dead_layer_dims=None,
+            device=torch.device(device),
+            fill=0.01,
+        )
+        params = list(model.parameters())
+        optimizer = self._shampoo_optim_factory(distributed_config=DDPShampooConfig())(
+            params
+        )
+        assert isinstance(optimizer, DistributedShampoo)
+        for _ in range(3):
+            optimizer.zero_grad()
+            objective = loss(model(data), target)
+            objective.backward()
+            optimizer.step()
 
-        @staticmethod
-        def _shampoo_optim_factory(
-            distributed_config: DDPShampooConfig | None,
-        ) -> Callable[[ParamsT], torch.optim.Optimizer]:
-            return partial(
-                DistributedShampoo,
-                lr=0.001,
-                betas=(0.9, 1.0),
-                epsilon=1e-8,
-                momentum=0.9,
-                weight_decay=0.0,
-                max_preconditioner_dim=PRECONDITIONER_DIM,
-                precondition_frequency=1,
-                start_preconditioning_step=2,
-                use_decoupled_weight_decay=True,
-                grafting_config=AdaGradGraftingConfig(
-                    epsilon=1e-8,
-                ),
-                distributed_config=distributed_config,
-            )
+        # Retrieve the distributed state dictionary of the first layer (i.e., the only layer) from the optimizer.
+        distributed_state_dict = optimizer.distributed_state_dict(
+            key_to_param=model.named_parameters(), save_param_groups=False
+        )["state"]["linear_layers.0.weight"]
 
-        def test_losses(self) -> None:
-            self._init_distributed()
-            for num_trainers_per_group, (
-                communication_dtype,
-                communicate_params,
-                (rtol, atol),
-            ) in product(
-                (-1, 1, 2),
-                (
-                    # Expecting CommunicationDType.DEFAULT would have bitwise identical results (by setting rtol=atol=0.0).
-                    (CommunicationDType.DEFAULT, False, (0.0, 0.0)),
-                    (CommunicationDType.DEFAULT, True, (0.0, 0.0)),
-                    # Using FP16 for distributed parameters prohibitively lowers precision.
-                    (
-                        CommunicationDType.FP16,
-                        False,
-                        default_tolerances(torch.float16),
+        # Define the expected distributed state dictionary for each rank.
+        rank_to_expected_distributed_state_dict = {
+            1: {
+                '["block_1", "shampoo", "factor_matrices", 0]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [0.0004, 0.0004, 0.0004],
+                            [0.0004, 0.0004, 0.0004],
+                            [0.0004, 0.0004, 0.0004],
+                        ]
                     ),
-                    (
-                        CommunicationDType.BF16,
-                        False,
-                        # BF16 requires 2x tolerances than the original bfloat16 tolerances.
-                        [2 * tol for tol in default_tolerances(torch.bfloat16)],
-                    ),
+                    device_mesh=DeviceMesh(str(device), [1]),
+                    placements=(Replicate(),),
                 ),
+                '["block_1", "shampoo", "factor_matrices", 1]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [0.0002, 0.0003, 0.0004],
+                            [0.0003, 0.0004, 0.0005],
+                            [0.0004, 0.0005, 0.0006],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [1]),
+                    placements=(Replicate(),),
+                ),
+                '["block_1", "shampoo", "inv_factor_matrices", 0]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [68.2723, -31.3830, -31.4793],
+                            [-31.3830, 68.3608, -31.5677],
+                            [-31.4793, -31.5677, 68.4570],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [1]),
+                    placements=(Replicate(),),
+                ),
+                '["block_1", "shampoo", "inv_factor_matrices", 1]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [82.9738, -22.7016, -28.3770],
+                            [-22.7016, 69.6087, -37.7380],
+                            [-28.3770, -37.7380, 52.6266],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [1]),
+                    placements=(Replicate(),),
+                ),
+                '["block_1", "adagrad"]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [7.0041e-05, 1.2452e-04, 1.9456e-04],
+                            [7.0041e-05, 1.2452e-04, 1.9456e-04],
+                            [7.0041e-05, 1.2452e-04, 1.9456e-04],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [1]),
+                    placements=(Replicate(),),
+                ),
+                '["block_1", "momentum"]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [1.6924, 1.9865, 2.2806],
+                            [1.6924, 1.9865, 2.2806],
+                            [1.6924, 1.9865, 2.2806],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [1]),
+                    placements=(Replicate(),),
+                ),
+                '["block_1", "filtered_grad"]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [0.0013, 0.0017, 0.0021],
+                            [0.0013, 0.0017, 0.0021],
+                            [0.0013, 0.0017, 0.0021],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [1]),
+                    placements=(Replicate(),),
+                ),
+                '["step"]': tensor(3),
+            },
+            0: {
+                '["block_0", "shampoo", "factor_matrices", 0]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [3.8911e-05, 3.8911e-05, 3.8911e-05],
+                            [3.8911e-05, 3.8911e-05, 3.8911e-05],
+                            [3.8911e-05, 3.8911e-05, 3.8911e-05],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [0]),
+                    placements=(Replicate(),),
+                ),
+                '["block_0", "shampoo", "factor_matrices", 1]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [0.0000e00, 0.0000e00, 0.0000e00],
+                            [0.0000e00, 2.3347e-05, 4.6694e-05],
+                            [0.0000e00, 4.6694e-05, 9.3387e-05],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [0]),
+                    placements=(Replicate(),),
+                ),
+                '["block_0", "shampoo", "inv_factor_matrices", 0]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [69.8735, -30.1266, -30.1266],
+                            [-30.1266, 69.8674, -30.1204],
+                            [-30.1266, -30.1204, 69.8673],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [0]),
+                    placements=(Replicate(),),
+                ),
+                '["block_0", "shampoo", "inv_factor_matrices", 1]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [100.0000, 0.0000, 0.0000],
+                            [0.0000, 81.9241, -36.1519],
+                            [0.0000, -36.1519, 27.6963],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [0]),
+                    placements=(Replicate(),),
+                ),
+                '["block_0", "adagrad"]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [0.0000e00, 7.7823e-06, 3.1129e-05],
+                            [0.0000e00, 7.7823e-06, 3.1129e-05],
+                            [0.0000e00, 7.7823e-06, 3.1129e-05],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [0]),
+                    placements=(Replicate(),),
+                ),
+                '["block_0", "momentum"]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [0.0000, 1.5694, 2.3289],
+                            [0.0000, 1.5694, 2.3289],
+                            [0.0000, 1.5694, 2.3289],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [0]),
+                    placements=(Replicate(),),
+                ),
+                '["block_0", "filtered_grad"]': DTensor.from_local(
+                    local_tensor=tensor(
+                        [
+                            [0.0000, 0.0004, 0.0009],
+                            [0.0000, 0.0004, 0.0009],
+                            [0.0000, 0.0004, 0.0009],
+                        ]
+                    ),
+                    device_mesh=DeviceMesh(str(device), [0]),
+                    placements=(Replicate(),),
+                ),
+                '["step"]': tensor(3),
+            },
+        }
+
+        # Because DTensor does not support comparison, the verification has to be performed in two stages:
+        # 1. Comparing the key sets are identical.
+        # 2. Comparing the values are identical by converting it into local tensor.
+
+        # Assert that the keys in the state dictionary match the expected keys for the current rank.
+        self.assertEqual(
+            distributed_state_dict.keys(),
+            rank_to_expected_distributed_state_dict[dist.get_rank()].keys(),
+        )
+
+        # Helper function to get the local tensor from a DTensor or return the tensor itself.
+        def local_tensor_getter(t: torch.Tensor | DTensor) -> torch.Tensor:
+            return t.to_local() if isinstance(t, DTensor) else t
+
+        # Compare each value in the state dictionary with the expected values.
+        for key, actual_val in distributed_state_dict.items():
+            expected_val = rank_to_expected_distributed_state_dict[dist.get_rank()][key]
+            with self.subTest(
+                key=key, actual_val=actual_val, expected_val=expected_val
             ):
-                with self.subTest(
-                    communication_dtype=communication_dtype,
-                    num_trainers_per_group=num_trainers_per_group,
-                    communicate_params=communicate_params,
-                ):
-                    compare_two_optimizers_on_weight_and_loss(
-                        control_optim_factory=self._shampoo_optim_factory(
-                            distributed_config=None,
-                        ),
-                        experimental_optim_factory=self._shampoo_optim_factory(
-                            distributed_config=DDPShampooConfig(
-                                communication_dtype=communication_dtype,
-                                num_trainers_per_group=num_trainers_per_group,
-                                communicate_params=communicate_params,
-                            )
-                        ),
-                        model_linear_layers_dims=(
-                            PRECONDITIONER_DIM * 4,
-                            PRECONDITIONER_DIM * 2,
-                            1,
-                        ),
-                        model_dead_layer_dims=(PRECONDITIONER_DIM, PRECONDITIONER_DIM),
-                        device=self._device,
-                        fill=0.01,
-                        rtol=rtol,
-                        atol=atol,
-                    )
+                torch.testing.assert_close(
+                    local_tensor_getter(actual_val),
+                    local_tensor_getter(expected_val),
+                    atol=1e-4,
+                    rtol=2e-1,
+                )
 
-        def test_distributed_state_dict(self) -> None:
-            self._init_distributed()
+    # This mock is used to catch the number of calls to Shampoo's step(), which happened after __init__().
+    # If there is no blocked params, __init__() will raise and step() should not be called.
+    # Otherwise, step() will be called.
+    def test_empty_local_blocked_params(self, device: str) -> None:
+        self._init_distributed(device=device)
 
-            model, loss, data, target = construct_training_problem(
-                # Setting model_linear_layers_dims to creates an model with one linear layer with (PRECONDITIONER_DIM * 2)xPRECONDITIONER_DIM weight.
-                # Because Shampoo's max_preconditioner_dim = PRECONDITIONER_DIM, there will be two blocks; rank 0 has block 0 and rank 1 has block 1.
-                model_linear_layers_dims=(PRECONDITIONER_DIM * 2, PRECONDITIONER_DIM),
+        # The test setting is only rank 0 has params, so all other ranks have no parameters to work on.
+        has_blocked_params = dist.get_rank() == 0
+        with mock.patch.object(DistributedShampoo, "step") as mock_step, (
+            contextlib.nullcontext()
+            if has_blocked_params
+            else self.assertRaisesRegex(
+                AssertionError,
+                re.escape("Some workers have no parameters to work on."),
+            )
+        ):
+            self._train_model(
+                self._shampoo_optim_factory(distributed_config=DDPShampooConfig()),
+                device=torch.device(device),
+                # Setting model_linear_layers_dims to (PRECONDITIONER_DIM, 1) creates an model with one linear layer with PRECONDITIONER_DIMx1 weight.
+                # Because Shampoo's max_preconditioner_dim = PRECONDITIONER_DIM, there will be only one block.
+                # In the case of two trainers per group, there will be one trainer has no params to work on.
+                model_linear_layers_dims=(PRECONDITIONER_DIM, 1),
                 model_dead_layer_dims=None,
-                device=self._device,
-                fill=0.01,
-            )
-            params = list(model.parameters())
-            optimizer = self._shampoo_optim_factory(
-                distributed_config=DDPShampooConfig()
-            )(params)
-            assert isinstance(optimizer, DistributedShampoo)
-            for _ in range(3):
-                optimizer.zero_grad()
-                objective = loss(model(data), target)
-                objective.backward()
-                optimizer.step()
-
-            # Retrieve the distributed state dictionary of the first layer (i.e., the only layer) from the optimizer.
-            distributed_state_dict = optimizer.distributed_state_dict(
-                key_to_param=model.named_parameters(), save_param_groups=False
-            )["state"]["linear_layers.0.weight"]
-
-            # Define the expected distributed state dictionary for each rank.
-            rank_to_expected_distributed_state_dict = {
-                1: {
-                    '["block_1", "shampoo", "factor_matrices", 0]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [0.0004, 0.0004, 0.0004],
-                                [0.0004, 0.0004, 0.0004],
-                                [0.0004, 0.0004, 0.0004],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [1]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_1", "shampoo", "factor_matrices", 1]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [0.0002, 0.0003, 0.0004],
-                                [0.0003, 0.0004, 0.0005],
-                                [0.0004, 0.0005, 0.0006],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [1]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_1", "shampoo", "inv_factor_matrices", 0]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [68.2723, -31.3830, -31.4793],
-                                [-31.3830, 68.3608, -31.5677],
-                                [-31.4793, -31.5677, 68.4570],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [1]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_1", "shampoo", "inv_factor_matrices", 1]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [82.9738, -22.7016, -28.3770],
-                                [-22.7016, 69.6087, -37.7380],
-                                [-28.3770, -37.7380, 52.6266],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [1]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_1", "adagrad"]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [7.0041e-05, 1.2452e-04, 1.9456e-04],
-                                [7.0041e-05, 1.2452e-04, 1.9456e-04],
-                                [7.0041e-05, 1.2452e-04, 1.9456e-04],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [1]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_1", "momentum"]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [1.6924, 1.9865, 2.2806],
-                                [1.6924, 1.9865, 2.2806],
-                                [1.6924, 1.9865, 2.2806],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [1]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_1", "filtered_grad"]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [0.0013, 0.0017, 0.0021],
-                                [0.0013, 0.0017, 0.0021],
-                                [0.0013, 0.0017, 0.0021],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [1]),
-                        placements=(Replicate(),),
-                    ),
-                    '["step"]': tensor(3),
-                },
-                0: {
-                    '["block_0", "shampoo", "factor_matrices", 0]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [3.8911e-05, 3.8911e-05, 3.8911e-05],
-                                [3.8911e-05, 3.8911e-05, 3.8911e-05],
-                                [3.8911e-05, 3.8911e-05, 3.8911e-05],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [0]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_0", "shampoo", "factor_matrices", 1]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [0.0000e00, 0.0000e00, 0.0000e00],
-                                [0.0000e00, 2.3347e-05, 4.6694e-05],
-                                [0.0000e00, 4.6694e-05, 9.3387e-05],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [0]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_0", "shampoo", "inv_factor_matrices", 0]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [69.8735, -30.1266, -30.1266],
-                                [-30.1266, 69.8674, -30.1204],
-                                [-30.1266, -30.1204, 69.8673],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [0]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_0", "shampoo", "inv_factor_matrices", 1]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [100.0000, 0.0000, 0.0000],
-                                [0.0000, 81.9241, -36.1519],
-                                [0.0000, -36.1519, 27.6963],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [0]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_0", "adagrad"]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [0.0000e00, 7.7823e-06, 3.1129e-05],
-                                [0.0000e00, 7.7823e-06, 3.1129e-05],
-                                [0.0000e00, 7.7823e-06, 3.1129e-05],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [0]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_0", "momentum"]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [0.0000, 1.5694, 2.3289],
-                                [0.0000, 1.5694, 2.3289],
-                                [0.0000, 1.5694, 2.3289],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [0]),
-                        placements=(Replicate(),),
-                    ),
-                    '["block_0", "filtered_grad"]': DTensor.from_local(
-                        local_tensor=tensor(
-                            [
-                                [0.0000, 0.0004, 0.0009],
-                                [0.0000, 0.0004, 0.0009],
-                                [0.0000, 0.0004, 0.0009],
-                            ]
-                        ),
-                        device_mesh=DeviceMesh(str(self._device), [0]),
-                        placements=(Replicate(),),
-                    ),
-                    '["step"]': tensor(3),
-                },
-            }
-
-            # Because DTensor does not support comparison, the verification has to be performed in two stages:
-            # 1. Comparing the key sets are identical.
-            # 2. Comparing the values are identical by converting it into local tensor.
-
-            # Assert that the keys in the state dictionary match the expected keys for the current rank.
-            self.assertEqual(
-                distributed_state_dict.keys(),
-                rank_to_expected_distributed_state_dict[dist.get_rank()].keys(),
             )
 
-            # Helper function to get the local tensor from a DTensor or return the tensor itself.
-            def local_tensor_getter(t: torch.Tensor | DTensor) -> torch.Tensor:
-                return t.to_local() if isinstance(t, DTensor) else t
+        if has_blocked_params:
+            mock_step.assert_called()
+        else:
+            mock_step.assert_not_called()
 
-            # Compare each value in the state dictionary with the expected values.
-            for key, actual_val in distributed_state_dict.items():
-                expected_val = rank_to_expected_distributed_state_dict[dist.get_rank()][
-                    key
-                ]
-                with self.subTest(
-                    key=key, actual_val=actual_val, expected_val=expected_val
-                ):
-                    torch.testing.assert_close(
-                        local_tensor_getter(actual_val),
-                        local_tensor_getter(expected_val),
-                        atol=1e-4,
-                        rtol=2e-1,
-                    )
+    def test_unsupported_communication_dtype(self, device: str) -> None:
+        self._init_distributed(device=device)
 
-        # This mock is used to catch the number of calls to Shampoo's step(), which happened after __init__().
-        # If there is no blocked params, __init__() will raise and step() should not be called.
-        # Otherwise, step() will be called.
-        @mock.patch.object(DistributedShampoo, "step")
-        def test_empty_local_blocked_params(self, mock_step: mock.Mock) -> None:
-            self._init_distributed()
-
-            # The test setting is only rank 0 has params, so all other ranks have no parameters to work on.
-            has_blocked_params = dist.get_rank() == 0
-            with (
-                contextlib.nullcontext()
-                if has_blocked_params
-                else self.assertRaisesRegex(
-                    AssertionError,
-                    re.escape("Some workers have no parameters to work on."),
-                )
-            ):
-                AbstractTest.ShampooDDPDistributorDeviceTest._train_model(
-                    self._shampoo_optim_factory(distributed_config=DDPShampooConfig()),
-                    device=self._device,
-                    # Setting model_linear_layers_dims to (PRECONDITIONER_DIM, 1) creates an model with one linear layer with PRECONDITIONER_DIMx1 weight.
-                    # Because Shampoo's max_preconditioner_dim = PRECONDITIONER_DIM, there will be only one block.
-                    # In the case of two trainers per group, there will be one trainer has no params to work on.
-                    model_linear_layers_dims=(PRECONDITIONER_DIM, 1),
-                    model_dead_layer_dims=None,
-                )
-
-            if has_blocked_params:
-                mock_step.assert_called()
-            else:
-                mock_step.assert_not_called()
-
-        def test_unsupported_communication_dtype(self) -> None:
-            self._init_distributed()
-
-            with mock.patch.object(CommunicationDType, "__eq__", return_value=False):
-                self.assertRaisesRegex(
-                    NotImplementedError,
-                    re.escape(
-                        "Unsupported communication dtype: CommunicationDType.DEFAULT"
-                    ),
-                    AbstractTest.ShampooDDPDistributorDeviceTest._train_model,
-                    self._shampoo_optim_factory(distributed_config=DDPShampooConfig()),
-                    device=self._device,
-                )
+        with mock.patch.object(CommunicationDType, "__eq__", return_value=False):
+            self.assertRaisesRegex(
+                NotImplementedError,
+                re.escape(
+                    "Unsupported communication dtype: CommunicationDType.DEFAULT"
+                ),
+                self._train_model,
+                self._shampoo_optim_factory(distributed_config=DDPShampooConfig()),
+                device=device,
+            )
 
 
-class ShampooDDPDistributorCPUTest(AbstractTest.ShampooDDPDistributorDeviceTest):
-    @property
-    def _device(self) -> torch.device:
-        return torch.device("cpu")
-
-
-@unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
-class ShampooDDPDistributorGPUTest(AbstractTest.ShampooDDPDistributorDeviceTest):
-    @property
-    def _device(self) -> torch.device:
-        return torch.device("cuda")
+instantiate_device_type_tests(
+    ShampooDDPDistributorDeviceTest,
+    globals(),
+    # Only test GPU and CPU.
+    only_for=("cuda", "cpu"),
+)

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -42,6 +42,10 @@ from matrix_functions_types import (
     RootInvConfig,
 )
 from torch import Tensor
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 
 class CheckDiagonalTest(unittest.TestCase):
@@ -62,6 +66,7 @@ class CheckDiagonalTest(unittest.TestCase):
         self.assertTrue(check_diagonal(A))
 
 
+@instantiate_parametrized_tests
 class MatrixInverseRootTest(unittest.TestCase):
     def test_matrix_inverse_root_scalar(self) -> None:
         A = torch.tensor(2.0)
@@ -108,85 +113,55 @@ class MatrixInverseRootTest(unittest.TestCase):
             is_diagonal=False,
         )
 
-    def test_matrix_inverse_root(self) -> None:
-        A_list = [
+    @parametrize(
+        "root_inv_config",
+        (
+            EigenConfig(),
+            CoupledNewtonConfig(),
+            EigenConfig(enhance_stability=True),
+            EigenConfig(eigendecomposition_offload_device="cpu"),
+            *(CoupledHigherOrderConfig(order=order) for order in range(2, 7)),
+        ),
+    )
+    @parametrize("exp", (1, 2))
+    @parametrize(
+        "A, expected_root",
+        (
             # A diagonal matrix.
-            torch.tensor([[1.0, 0.0], [0.0, 4.0]]),
-            # Non-diagonal matrix.
-            torch.tensor(
-                [
-                    [1195.0, -944.0, -224.0],
-                    [-944.0, 746.0, 177.0],
-                    [-224.0, 177.0, 42.0],
-                ]
+            (
+                torch.tensor([[1.0, 0.0], [0.0, 4.0]]),
+                torch.tensor([[1.0, 0.0], [0.0, 0.5]]),
             ),
-        ]
-        root = Fraction(2)
-        expected_root_list = [
-            torch.tensor([[1.0, 0.0], [0.0, 0.5]]),
-            torch.tensor([[1.0, 1.0, 1.0], [1.0, 2.0, -3.0], [1.0, -3.0, 18.0]]),
-        ]
-
+            # Non-diagonal matrix.
+            (
+                torch.tensor(
+                    [
+                        [1195.0, -944.0, -224.0],
+                        [-944.0, 746.0, 177.0],
+                        [-224.0, 177.0, 42.0],
+                    ]
+                ),
+                torch.tensor([[1.0, 1.0, 1.0], [1.0, 2.0, -3.0], [1.0, -3.0, 18.0]]),
+            ),
+        ),
+    )
+    def test_matrix_inverse_root(
+        self, A: Tensor, expected_root: Tensor, exp: int, root_inv_config: RootInvConfig
+    ) -> None:
         atol = 0.05
         rtol = 1e-2
-        with self.subTest("Test with diagonal case."):
-            torch.testing.assert_close(
-                expected_root_list[0],
-                matrix_inverse_root(
-                    A_list[0],
-                    root=root,
-                    is_diagonal=True,
-                ),
-                atol=atol,
-                rtol=rtol,
-            )
 
-        for A, expected_root in zip(A_list, expected_root_list, strict=True):
-            for root_inv_config in (
-                EigenConfig(),
-                CoupledNewtonConfig(),
-                EigenConfig(enhance_stability=True),
-                EigenConfig(eigendecomposition_offload_device="cpu"),
-            ):
-                with self.subTest(f"Test with {A=}, {root_inv_config=}"):
-                    torch.testing.assert_close(
-                        expected_root,
-                        matrix_inverse_root(
-                            A=A,
-                            root=root,
-                            is_diagonal=False,
-                            root_inv_config=root_inv_config,
-                        ),
-                        atol=atol,
-                        rtol=rtol,
-                    )
-
-            for order in range(2, 7):
-                with self.subTest(f"Test HIGHER_ORDER with {A=}, {order=}"):
-                    torch.testing.assert_close(
-                        expected_root,
-                        matrix_inverse_root(
-                            A=A,
-                            root=root,
-                            is_diagonal=False,
-                            root_inv_config=CoupledHigherOrderConfig(order=order),
-                        ),
-                        atol=atol,
-                        rtol=rtol,
-                    )
-                    # Also test that powering works
-                    exp = 2
-                    torch.testing.assert_close(
-                        torch.linalg.matrix_power(expected_root, exp),
-                        matrix_inverse_root(
-                            A,
-                            root=Fraction(root // exp),
-                            root_inv_config=CoupledHigherOrderConfig(order=order),
-                            is_diagonal=False,
-                        ),
-                        atol=atol,
-                        rtol=rtol,
-                    )
+        torch.testing.assert_close(
+            torch.linalg.matrix_power(expected_root, exp),
+            matrix_inverse_root(
+                A=A,
+                root=Fraction(2, exp),
+                is_diagonal=False,
+                root_inv_config=root_inv_config,
+            ),
+            atol=atol,
+            rtol=rtol,
+        )
 
     def test_matrix_inverse_root_higher_order_blowup(self) -> None:
         A = torch.tensor([[1.0, 0.0], [0.0, 1e-4]])
@@ -215,54 +190,44 @@ class MatrixInverseRootTest(unittest.TestCase):
             root_inv_config=CoupledNewtonConfig(),
         )
 
-    def test_matrix_inverse_root_reach_max_iterations(self) -> None:
-        A = torch.tensor([[1.0, 0.0], [0.0, 4.0]])
-        root = Fraction(4)
-        root_inv_config_and_implementation_and_msg: list[
-            tuple[RootInvConfig, str, str]
-        ] = [
+    @parametrize(
+        "root_inv_config, implementation, msg",
+        [
             (CoupledNewtonConfig(), "_matrix_inverse_root_newton", "Newton"),
             (
                 CoupledHigherOrderConfig(),
                 "_matrix_inverse_root_higher_order",
                 "Higher order method",
             ),
-        ]
-        for (
-            root_inv_config,
+        ],
+    )
+    def test_matrix_inverse_root_reach_max_iterations(
+        self, root_inv_config: RootInvConfig, implementation: str, msg: str
+    ) -> None:
+        A = torch.tensor([[1.0, 0.0], [0.0, 4.0]])
+        root = Fraction(4)
+        with mock.patch.object(
+            matrix_functions,
             implementation,
-            msg,
-        ) in root_inv_config_and_implementation_and_msg:
-            with (
-                mock.patch.object(
-                    matrix_functions,
-                    implementation,
-                    return_value=(
-                        None,
-                        None,
-                        NewtonConvergenceFlag.REACHED_MAX_ITERS,
-                        None,
-                        None,
-                    ),
-                ),
-                self.subTest(
-                    root_inv_config=root_inv_config,
-                    implementation=implementation,
-                    msg=msg,
-                ),
-                self.assertLogs(
-                    level="WARNING",
-                ) as cm,
-            ):
-                matrix_inverse_root(
-                    A=A,
-                    root=root,
-                    root_inv_config=root_inv_config,
-                )
-                self.assertIn(
-                    f"{msg} did not converge and reached maximum number of iterations!",
-                    [r.msg for r in cm.records],
-                )
+            return_value=(
+                None,
+                None,
+                NewtonConvergenceFlag.REACHED_MAX_ITERS,
+                None,
+                None,
+            ),
+        ), self.assertLogs(
+            level="WARNING",
+        ) as cm:
+            matrix_inverse_root(
+                A=A,
+                root=root,
+                root_inv_config=root_inv_config,
+            )
+            self.assertIn(
+                f"{msg} did not converge and reached maximum number of iterations!",
+                [r.msg for r in cm.records],
+            )
 
     def test_matrix_inverse_root_higher_order_tf32_preservation(self) -> None:
         A = torch.tensor([[1.0, 0.0], [0.0, float("inf")]])
@@ -285,16 +250,15 @@ class MatrixInverseRootTest(unittest.TestCase):
         # Trigger this error by using an ill-conditioned matrix.
         A = torch.tensor([[1.0, 0.0], [0.0, 1e-4]])
         root = Fraction(2)
-        with self.assertRaisesRegex(
+        self.assertRaisesRegex(
             ArithmeticError,
-            "Error in matrix inverse root \\(before powering for fractions\\) [+-]?([0-9]*[.])?[0-9]+ exceeds threshold 1e-1, raising an exception!",
-        ):
-            matrix_inverse_root(
-                A=A,
-                root=root,
-                # Set max_iterations to 0 to fast forward to the error check before powering.
-                root_inv_config=CoupledHigherOrderConfig(max_iterations=0),
-            )
+            r"Error in matrix inverse root \(before powering for fractions\) [+-]?([0-9]*[.])?[0-9]+ exceeds threshold 1e-1, raising an exception!",
+            matrix_inverse_root,
+            A=A,
+            root=root,
+            # Set max_iterations to 0 to fast forward to the error check before powering.
+            root_inv_config=CoupledHigherOrderConfig(max_iterations=0),
+        )
 
     def test_matrix_inverse_root_with_invalid_root_inv_config(self) -> None:
         @dataclass
@@ -316,158 +280,139 @@ class MatrixInverseRootTest(unittest.TestCase):
         )
 
 
+@instantiate_parametrized_tests
 class MatrixRootDiagonalTest(unittest.TestCase):
-    def test_matrix_root_diagonal_nonpositive_root(self) -> None:
+    @parametrize("root", (-1, 0))
+    def test_matrix_root_diagonal_nonpositive_root(self, root: int) -> None:
         A = torch.tensor([[-1.0, 0.0], [0.0, 2.0]])
-        for root in (-1, 0):
-            with self.subTest(f"With {root=}"):
-                self.assertRaisesRegex(
-                    ValueError,
-                    re.escape(f"Root {root} should be positive!"),
-                    matrix_inverse_root,
-                    A=A,
-                    root=root,
-                    is_diagonal=True,
-                )
-
-
-class EigenRootTest(unittest.TestCase):
-    def _test_eigen_root(
-        self,
-        A: torch.Tensor,
-        root: int,
-        epsilon: float,
-        tolerance: float,
-        eig_sols: Tensor,
-    ) -> None:
-        X, L, Q = _matrix_inverse_root_eigen(
+        self.assertRaisesRegex(
+            ValueError,
+            re.escape(f"Root {root} should be positive!"),
+            matrix_inverse_root,
             A=A,
-            root=Fraction(root),
-            epsilon=epsilon,
+            root=root,
+            is_diagonal=True,
         )
-        abs_error = torch.dist(torch.linalg.matrix_power(X, -root), A, p=torch.inf)
-        A_norm = torch.linalg.norm(A, ord=torch.inf)
-        rel_error = abs_error / torch.maximum(torch.tensor(1.0), A_norm)
-        torch.testing.assert_close(L, eig_sols)
-        self.assertLessEqual(rel_error.item(), tolerance)
 
+    def test_matrix_root(self) -> None:
+        A = torch.tensor([[1.0, 0.0], [0.0, 4.0]])
+        root = Fraction(2)
+        expected_root_list = torch.tensor([[1.0, 0.0], [0.0, 0.5]])
+
+        torch.testing.assert_close(
+            expected_root_list,
+            matrix_inverse_root(
+                A,
+                root=root,
+                is_diagonal=True,
+            ),
+        )
+
+
+@instantiate_parametrized_tests
+class EigenRootTest(unittest.TestCase):
     def _test_eigen_root_multi_dim(
         self,
         A: Callable[[int], Tensor],
-        dims: list[int],
-        roots: list[int],
-        epsilons: list[float],
+        n: int,
+        root: int,
+        epsilon: float,
         tolerance: float,
         eig_sols: Callable[[int], Tensor],
     ) -> None:
-        for n, root, epsilon in itertools.product(dims, roots, epsilons):
-            with self.subTest(f"With dim = {n}, root = {root}, epsilon = {epsilon}"):
-                self._test_eigen_root(
-                    A(n),
-                    root,
-                    epsilon,
-                    tolerance,
-                    eig_sols(n),
-                )
+        X, L, Q = _matrix_inverse_root_eigen(
+            A=A(n),
+            root=Fraction(root),
+            epsilon=epsilon,
+        )
+        abs_error = torch.dist(torch.linalg.matrix_power(X, -root), A(n), p=torch.inf)
+        A_norm = torch.linalg.norm(A(n), ord=torch.inf)
+        rel_error = abs_error / torch.maximum(torch.tensor(1.0), A_norm)
+        torch.testing.assert_close(L, eig_sols(n))
+        self.assertLessEqual(rel_error.item(), tolerance)
 
-    def test_eigen_root_identity(self) -> None:
-        tolerance = 1e-6
-        dims = [10, 100]
-        roots = [1, 2, 4, 8]
-        epsilons = [0.0]
+    @parametrize("epsilon", [0.0])
+    @parametrize("root", [1, 2, 4, 8])
+    @parametrize("n", [10, 100])
+    def test_eigen_root_identity(self, n: int, root: int, epsilon: float) -> None:
+        self._test_eigen_root_multi_dim(
+            A=torch.eye,
+            n=n,
+            root=root,
+            epsilon=epsilon,
+            tolerance=1e-6,
+            eig_sols=torch.ones,
+        )
 
-        def eig_sols(n: int) -> Tensor:
-            return torch.ones(n)
+    @parametrize(  # type: ignore
+        "alpha, beta",
+        [
+            (alpha, beta)
+            for alpha, beta in itertools.product(
+                (0.001, 0.01, 0.1, 1.0, 10.0, 100.0), repeat=2
+            )
+            if 2 * beta <= alpha
+        ],
+    )
+    @parametrize("epsilon", [0.0])
+    @parametrize("root", [1, 2, 4, 8])
+    @parametrize("n", [10, 100])
+    def test_eigen_root_tridiagonal(
+        self, n: int, root: int, epsilon: float, alpha: float, beta: float
+    ) -> None:
+        def eig_sols_tridiagonal_1(n: int, alpha: float, beta: float) -> Tensor:
+            eigs = alpha * torch.ones(n) + 2 * beta * torch.tensor(
+                [np.cos(j * torch.pi / n) for j in range(n)], dtype=torch.float
+            )
+            eigs, _ = torch.sort(eigs)
+            return eigs
 
-        def A(n: int) -> Tensor:
-            return torch.eye(n)
+        def A_tridiagonal_1(n: int, alpha: float, beta: float) -> Tensor:
+            diag = alpha * torch.ones(n)
+            diag[0] += beta
+            diag[n - 1] += beta
+            off_diag = beta * torch.ones(n - 1)
+            return (
+                torch.diag(diag)
+                + torch.diag(off_diag, diagonal=1)
+                + torch.diag(off_diag, diagonal=-1)
+            )
 
-        self._test_eigen_root_multi_dim(A, dims, roots, epsilons, tolerance, eig_sols)
+        self._test_eigen_root_multi_dim(
+            A=partial(A_tridiagonal_1, alpha=alpha, beta=beta),
+            n=n,
+            root=root,
+            epsilon=epsilon,
+            tolerance=1e-4,
+            eig_sols=partial(eig_sols_tridiagonal_1, alpha=alpha, beta=beta),
+        )
 
-    def test_eigen_root_tridiagonal_1(self) -> None:
-        tolerance = 1e-4
-        dims = [10, 100]
-        roots = [1, 2, 4, 8]
-        epsilons = [0.0]
+        def eig_sols_tridiagonal_2(n: int, alpha: float, beta: float) -> Tensor:
+            eigs = alpha * torch.ones(n) + 2 * beta * torch.tensor(
+                [np.cos(2 * j * torch.pi / (2 * n + 1)) for j in range(1, n + 1)],
+                dtype=torch.float,
+            )
+            eigs, _ = torch.sort(eigs)
+            return eigs
 
-        for alpha, beta in itertools.product(
-            [0.001, 0.01, 0.1, 1.0, 10.0, 100.0], repeat=2
-        ):
-            if 2 * beta > alpha:
-                continue
+        def A_tridiagonal_2(n: int, alpha: float, beta: float) -> Tensor:
+            diag = alpha * torch.ones(n)
+            diag[0] -= beta
+            off_diag = beta * torch.ones(n - 1)
+            return (
+                torch.diag(diag)
+                + torch.diag(off_diag, diagonal=1)
+                + torch.diag(off_diag, diagonal=-1)
+            )
 
-            with self.subTest(f"Test with alpha = {alpha}, beta = {beta}"):
-
-                def eig_sols(n: int, alpha: float, beta: float) -> Tensor:
-                    eigs = alpha * torch.ones(n) + 2 * beta * torch.tensor(
-                        [np.cos(j * torch.pi / n) for j in range(n)], dtype=torch.float
-                    )
-                    eigs, _ = torch.sort(eigs)
-                    return eigs
-
-                def A(n: int, alpha: float, beta: float) -> Tensor:
-                    diag = alpha * torch.ones(n)
-                    diag[0] += beta
-                    diag[n - 1] += beta
-                    off_diag = beta * torch.ones(n - 1)
-                    return (
-                        torch.diag(diag)
-                        + torch.diag(off_diag, diagonal=1)
-                        + torch.diag(off_diag, diagonal=-1)
-                    )
-
-                self._test_eigen_root_multi_dim(
-                    partial(A, alpha=alpha, beta=beta),
-                    dims,
-                    roots,
-                    epsilons,
-                    tolerance,
-                    partial(eig_sols, alpha=alpha, beta=beta),
-                )
-
-    def test_eigen_root_tridiagonal_2(self) -> None:
-        tolerance = 1e-4
-        dims = [10, 100]
-        roots = [1, 2, 4, 8]
-        epsilons = [0.0]
-
-        for alpha, beta in itertools.product(
-            [0.001, 0.01, 0.1, 1.0, 10.0, 100.0], repeat=2
-        ):
-            if 2 * beta > alpha:
-                continue
-
-            with self.subTest(f"Test with alpha = {alpha}, beta = {beta}"):
-
-                def eig_sols(n: int, alpha: float, beta: float) -> Tensor:
-                    eigs = alpha * torch.ones(n) + 2 * beta * torch.tensor(
-                        [
-                            np.cos(2 * j * torch.pi / (2 * n + 1))
-                            for j in range(1, n + 1)
-                        ],
-                        dtype=torch.float,
-                    )
-                    eigs, _ = torch.sort(eigs)
-                    return eigs
-
-                def A(n: int, alpha: float, beta: float) -> Tensor:
-                    diag = alpha * torch.ones(n)
-                    diag[0] -= beta
-                    off_diag = beta * torch.ones(n - 1)
-                    return (
-                        torch.diag(diag)
-                        + torch.diag(off_diag, diagonal=1)
-                        + torch.diag(off_diag, diagonal=-1)
-                    )
-
-                self._test_eigen_root_multi_dim(
-                    partial(A, alpha=alpha, beta=beta),
-                    dims,
-                    roots,
-                    epsilons,
-                    tolerance,
-                    partial(eig_sols, alpha=alpha, beta=beta),
-                )
+        self._test_eigen_root_multi_dim(
+            A=partial(A_tridiagonal_2, alpha=alpha, beta=beta),
+            n=n,
+            root=root,
+            epsilon=epsilon,
+            tolerance=1e-4,
+            eig_sols=partial(eig_sols_tridiagonal_2, alpha=alpha, beta=beta),
+        )
 
     def test_matrix_root_eigen_nonpositive_root(self) -> None:
         A = torch.tensor([[-1.0, 0.0], [0.0, 2.0]])
@@ -489,13 +434,15 @@ class EigenRootTest(unittest.TestCase):
         self, mock_eigh: mock.Mock
     ) -> None:
         A = torch.tensor([[-1.0, 0.0], [0.0, 2.0]])
-        with self.assertRaisesRegex(RuntimeError, re.escape("Mock Eigen Error")):
-            matrix_inverse_root(
-                A=A,
-                root=Fraction(2),
-                root_inv_config=EigenConfig(retry_double_precision=False),
-                epsilon=0.0,
-            )
+        self.assertRaisesRegex(
+            RuntimeError,
+            re.escape("Mock Eigen Error"),
+            matrix_inverse_root,
+            A=A,
+            root=Fraction(2),
+            root_inv_config=EigenConfig(retry_double_precision=False),
+            epsilon=0.0,
+        )
         mock_eigh.assert_called_once()
 
     @mock.patch.object(
@@ -503,12 +450,14 @@ class EigenRootTest(unittest.TestCase):
     )
     def test_retry_double_precision_raise_exception(self, mock_eigh: mock.Mock) -> None:
         A = torch.tensor([[-1.0, 0.0], [0.0, 2.0]])
-        with self.assertRaisesRegex(RuntimeError, re.escape("Mock Eigen Error")):
-            matrix_inverse_root(
-                A=A,
-                root=Fraction(2),
-                epsilon=0.0,
-            )
+        self.assertRaisesRegex(
+            RuntimeError,
+            re.escape("Mock Eigen Error"),
+            matrix_inverse_root,
+            A=A,
+            root=Fraction(2),
+            epsilon=0.0,
+        )
         mock_eigh.assert_called()
         self.assertEqual(mock_eigh.call_count, 2)
 
@@ -534,10 +483,12 @@ class EigenRootTest(unittest.TestCase):
         self.assertEqual(mock_eigh.call_count, 2)
 
 
+@instantiate_parametrized_tests
 class NewtonRootInverseTest(unittest.TestCase):
-    def _test_newton_root_inverse(
+    def _test_newton_root_inverse_multi_dim(
         self,
-        A: Tensor,
+        A: Callable[[int], Tensor],
+        n: int,
         root: int,
         epsilon: float,
         max_iterations: int,
@@ -545,117 +496,90 @@ class NewtonRootInverseTest(unittest.TestCase):
         M_tol: float,
     ) -> None:
         X, _, _, _, M_error = _matrix_inverse_root_newton(
-            A, root, epsilon, max_iterations, M_tol
+            A(n), root, epsilon, max_iterations, M_tol
         )
-        abs_A_error = torch.dist(torch.linalg.matrix_power(X, -root), A, p=torch.inf)
-        A_norm = torch.linalg.norm(A, ord=torch.inf)
+        abs_A_error = torch.dist(torch.linalg.matrix_power(X, -root), A(n), p=torch.inf)
+        A_norm = torch.linalg.norm(A(n), ord=torch.inf)
         rel_A_error = abs_A_error / torch.maximum(torch.tensor(1.0), A_norm)
         self.assertLessEqual(M_error.item(), M_tol)
         self.assertLessEqual(rel_A_error.item(), A_tol)
 
-    def _test_newton_root_inverse_multi_dim(
-        self,
-        A: Callable[[int], Tensor],
-        dims: list[int],
-        roots: list[int],
-        epsilons: list[float],
-        max_iterations: int,
-        A_tol: float,
-        M_tol: float,
+    @parametrize("epsilon", [0.0])
+    @parametrize("root", [2, 4, 8])
+    @parametrize("n", [10, 100])
+    def test_newton_root_inverse_identity(
+        self, n: int, root: int, epsilon: float
     ) -> None:
-        for n, root, epsilon in itertools.product(dims, roots, epsilons):
-            with self.subTest(f"With dim = {n}, root = {root}, epsilon = {epsilon}"):
-                self._test_newton_root_inverse(
-                    A(n), root, epsilon, max_iterations, A_tol, M_tol
-                )
-
-    def test_newton_root_inverse_identity(self) -> None:
-        A_tol = 1e-6
-        M_tol = 1e-6
         max_iterations = 1000
-        dims = [10, 100]
-        roots = [2, 4, 8]
-        epsilons = [0.0]
-
-        def A(n: int) -> Tensor:
-            return torch.eye(n)
 
         self._test_newton_root_inverse_multi_dim(
-            A, dims, roots, epsilons, max_iterations, A_tol, M_tol
+            A=torch.eye,
+            n=n,
+            root=root,
+            epsilon=epsilon,
+            max_iterations=max_iterations,
+            A_tol=1e-6,
+            M_tol=1e-6,
         )
 
-    def test_newton_root_inverse_tridiagonal_1(self) -> None:
-        A_tol = 1e-4
-        M_tol = 1e-6
+    @parametrize(  # type: ignore
+        "alpha, beta",
+        [
+            (alpha, beta)
+            for alpha, beta in itertools.product(
+                (0.001, 0.01, 0.1, 1.0, 10.0, 100.0), repeat=2
+            )
+            if 2 * beta <= alpha
+        ],
+    )
+    @parametrize("epsilon", [0.0])
+    @parametrize("root", [2, 4, 8])
+    @parametrize("n", [10, 100])
+    def test_newton_root_inverse_tridiagonal(
+        self, n: int, root: int, epsilon: float, alpha: float, beta: float
+    ) -> None:
         max_iterations = 1000
-        dims = [10, 100]
-        roots = [2, 4, 8]
-        epsilons = [0.0]
 
-        for alpha, beta in itertools.product(
-            [0.001, 0.01, 0.1, 1.0, 10.0, 100.0], repeat=2
-        ):
-            if 2 * beta > alpha:
-                continue
+        def A_tridiagonal_1(n: int, alpha: float, beta: float) -> Tensor:
+            diag = alpha * torch.ones(n)
+            diag[0] += beta
+            diag[n - 1] += beta
+            off_diag = beta * torch.ones(n - 1)
+            return (
+                torch.diag(diag)
+                + torch.diag(off_diag, diagonal=1)
+                + torch.diag(off_diag, diagonal=-1)
+            )
 
-            with self.subTest(f"Test with alpha = {alpha}, beta = {beta}"):
+        self._test_newton_root_inverse_multi_dim(
+            A=partial(A_tridiagonal_1, alpha=alpha, beta=beta),
+            n=n,
+            root=root,
+            epsilon=epsilon,
+            max_iterations=max_iterations,
+            A_tol=1e-4,
+            M_tol=1e-6,
+        )
 
-                def A(n: int, alpha: float, beta: float) -> Tensor:
-                    diag = alpha * torch.ones(n)
-                    diag[0] += beta
-                    diag[n - 1] += beta
-                    off_diag = beta * torch.ones(n - 1)
-                    return (
-                        torch.diag(diag)
-                        + torch.diag(off_diag, diagonal=1)
-                        + torch.diag(off_diag, diagonal=-1)
-                    )
+        def A_tridiagonal_2(n: int, alpha: float, beta: float) -> Tensor:
+            diag = alpha * torch.ones(n)
+            diag[0] -= beta
+            off_diag = beta * torch.ones(n - 1)
+            return (
+                torch.diag(diag)
+                + torch.diag(off_diag, diagonal=1)
+                + torch.diag(off_diag, diagonal=-1)
+            )
 
-                self._test_newton_root_inverse_multi_dim(
-                    partial(A, alpha=alpha, beta=beta),
-                    dims,
-                    roots,
-                    epsilons,
-                    max_iterations,
-                    A_tol,
-                    M_tol,
-                )
-
-    def test_newton_root_inverse_tridiagonal_2(self) -> None:
-        A_tol = 1e-4
-        M_tol = 1e-6
-        max_iterations = 1000
-        dims = [10, 100]
-        roots = [2, 4, 8]
-        epsilons = [0.0]
-
-        for alpha, beta in itertools.product(
-            [0.001, 0.01, 0.1, 1.0, 10.0, 100.0], repeat=2
-        ):
-            if 2 * beta > alpha:
-                continue
-
-            with self.subTest(f"Test with alpha = {alpha}, beta = {beta}"):
-
-                def A(n: int, alpha: float, beta: float) -> Tensor:
-                    diag = alpha * torch.ones(n)
-                    diag[0] -= beta
-                    off_diag = beta * torch.ones(n - 1)
-                    return (
-                        torch.diag(diag)
-                        + torch.diag(off_diag, diagonal=1)
-                        + torch.diag(off_diag, diagonal=-1)
-                    )
-
-                self._test_newton_root_inverse_multi_dim(
-                    partial(A, alpha=alpha, beta=beta),
-                    dims,
-                    roots,
-                    epsilons,
-                    max_iterations,
-                    A_tol,
-                    M_tol,
-                )
+        self._test_newton_root_inverse_multi_dim(
+            A=partial(A_tridiagonal_2, alpha=alpha, beta=beta),
+            n=n,
+            root=root,
+            epsilon=epsilon,
+            max_iterations=max_iterations,
+            A_tol=1e-4,
+            M_tol=1e-6,
+        )
 
 
 class CoupledHigherOrderRootInverseTest(unittest.TestCase):
@@ -670,12 +594,13 @@ class CoupledHigherOrderRootInverseTest(unittest.TestCase):
                 root=root,
                 root_inv_config=CoupledHigherOrderConfig(),
             )
-            self.assertIn(
-                "abs(root.numerator)=13 and abs(root.denominator)=15 are probably too big for best performance.",
-                [r.msg for r in cm.records],
-            )
+        self.assertIn(
+            "abs(root.numerator)=13 and abs(root.denominator)=15 are probably too big for best performance.",
+            [r.msg for r in cm.records],
+        )
 
 
+@instantiate_parametrized_tests
 class ComputeMatrixRootInverseResidualsTest(unittest.TestCase):
     def test_matrix_root_inverse_residuals_with_not_two_dim_matrix(self) -> None:
         A = torch.zeros((1, 2, 3))
@@ -719,14 +644,13 @@ class ComputeMatrixRootInverseResidualsTest(unittest.TestCase):
             epsilon=0.0,
         )
 
-    def _test_matrix_root_inverse_residuals(
-        self,
-        A: torch.Tensor,
-        X_hat: torch.Tensor,
-        root: Fraction,
-        expected_relative_error: torch.Tensor,
-        expected_relative_residual: torch.Tensor,
-    ) -> None:
+    @parametrize("root", (Fraction(2, 1), Fraction(4, 2)))
+    def test_matrix_root_inverse_residuals(self, root: Fraction) -> None:
+        A = torch.eye(2)
+        X_hat = torch.eye(2)
+        expected_relative_error = torch.tensor(0.0, dtype=torch.float64)
+        expected_relative_residual = torch.tensor(0.0, dtype=torch.float64)
+
         (
             actual_relative_error,
             actual_relative_residual,
@@ -745,34 +669,8 @@ class ComputeMatrixRootInverseResidualsTest(unittest.TestCase):
             expected_relative_residual,
         )
 
-    def test_matrix_root_inverse_residuals(self) -> None:
-        A = torch.eye(2)
-        X_hat = torch.eye(2)
-        expected_relative_error = torch.tensor(0.0, dtype=torch.float64)
-        expected_relative_residual = torch.tensor(0.0, dtype=torch.float64)
 
-        with self.subTest("Exponent = 1."):
-            exp = 1.0
-            root = Fraction(2.0 / exp)
-            self._test_matrix_root_inverse_residuals(
-                A=A,
-                X_hat=X_hat,
-                root=root,
-                expected_relative_error=expected_relative_error,
-                expected_relative_residual=expected_relative_residual,
-            )
-        with self.subTest("Exponent != 1."):
-            exp = 2.0
-            root = Fraction(4.0 / exp)
-            self._test_matrix_root_inverse_residuals(
-                A=A,
-                X_hat=X_hat,
-                root=root,
-                expected_relative_error=expected_relative_error,
-                expected_relative_residual=expected_relative_residual,
-            )
-
-
+@instantiate_parametrized_tests
 class MatrixEigendecompositionTest(unittest.TestCase):
     def test_matrix_eigendecomposition_scalar(self) -> None:
         A = torch.tensor(2.0)
@@ -805,114 +703,129 @@ class MatrixEigendecompositionTest(unittest.TestCase):
             A=A,
         )
 
-    def test_matrix_eigendecomposition(self) -> None:
-        A_list = [
-            torch.tensor([[1.0, 0.0], [0.0, 4.0]]),
-            torch.tensor(
-                [
-                    [1195.0, -944.0, -224.0],
-                    [-944.0, 746.0, 177.0],
-                    [-224.0, 177.0, 42.0],
-                ]
+    @parametrize(
+        "eigendecomposition_config",
+        (
+            DefaultEigendecompositionConfig,
+            EighEigendecompositionConfig(eigendecomposition_offload_device="cpu"),
+        ),
+    )
+    @parametrize(
+        "A, expected_eigenvalues, expected_eigenvectors",
+        (
+            # A diagonal matrix.
+            (
+                torch.tensor([[1.0, 0.0], [0.0, 4.0]]),
+                torch.tensor([1.0, 4.0]),
+                torch.tensor([[1.0, 0.0], [0.0, 1.0]]),
             ),
-        ]
-        expected_eigenvalues_list = [
-            torch.tensor([1.0, 4.0]),
-            torch.tensor([2.9008677229e-03, 1.7424316704e-01, 1.9828229980e03]),
-        ]
-        expected_eigenvectors_list = [
-            torch.tensor([[1.0, 0.0], [0.0, 1.0]]),
-            torch.tensor(
-                [
-                    [0.0460073575, -0.6286827326, 0.7762997746],
-                    [-0.1751257628, -0.7701635957, -0.6133345366],
-                    [0.9834705591, -0.1077321917, -0.1455317289],
-                ]
+            # Non-diagonal matrix.
+            (
+                torch.tensor(
+                    [
+                        [1195.0, -944.0, -224.0],
+                        [-944.0, 746.0, 177.0],
+                        [-224.0, 177.0, 42.0],
+                    ]
+                ),
+                torch.tensor([2.9008677229e-03, 1.7424316704e-01, 1.9828229980e03]),
+                torch.tensor(
+                    [
+                        [0.0460073575, -0.6286827326, 0.7762997746],
+                        [-0.1751257628, -0.7701635957, -0.6133345366],
+                        [0.9834705591, -0.1077321917, -0.1455317289],
+                    ]
+                ),
             ),
-        ]
-
+        ),
+    )
+    def test_matrix_eigendecomposition(
+        self,
+        A: Tensor,
+        expected_eigenvalues: Tensor,
+        expected_eigenvectors: Tensor,
+        eigendecomposition_config: EigendecompositionConfig,
+    ) -> None:
         atol = 1e-4
         rtol = 1e-5
-        with self.subTest("Test with diagonal case."):
-            torch.testing.assert_close(
-                (expected_eigenvalues_list[0], expected_eigenvectors_list[0]),
-                matrix_eigendecomposition(
-                    A_list[0],
-                    is_diagonal=True,
-                ),
-                atol=atol,
-                rtol=rtol,
-            )
-        with self.subTest("Test with EighEigendecompositionConfig."):
-            for (
-                A,
-                expected_eigenvalues,
-                expected_eigenvectors,
-            ), eigendecomposition_config in itertools.product(
-                zip(
-                    A_list,
-                    expected_eigenvalues_list,
-                    expected_eigenvectors_list,
-                    strict=True,
-                ),
-                (
-                    DefaultEigendecompositionConfig,
-                    EighEigendecompositionConfig(
-                        eigendecomposition_offload_device="cpu"
-                    ),
-                ),
-            ):
-                torch.testing.assert_close(
-                    (expected_eigenvalues, expected_eigenvectors),
-                    matrix_eigendecomposition(
-                        A,
-                        eigendecomposition_config=eigendecomposition_config,
-                        is_diagonal=False,
-                    ),
-                    atol=atol,
-                    rtol=rtol,
-                )
 
-        # Tests for `QREigendecompositionConfig`.
-        for name, initialization_fn, atol in (
-            ("zero", lambda A: torch.zeros_like(A), 1e-4),
-            (
-                "identity",
-                lambda A: torch.eye(A.shape[0], dtype=A.dtype, device=A.device),
-                2e-3,
+        torch.testing.assert_close(
+            (expected_eigenvalues, expected_eigenvectors),
+            matrix_eigendecomposition(
+                A,
+                eigendecomposition_config=eigendecomposition_config,
+                is_diagonal=False,
             ),
-            ("exact", lambda A: matrix_eigendecomposition(A)[1], 2e-3),
-        ):
-            with self.subTest(
-                f"Test with QREigendecompositionConfig with {name} initialization."
-            ):
-                # Set `max_iterations` to large int to run until numerical tolerance.
-                qr_config = QREigendecompositionConfig(max_iterations=10_000)
-                for A, expected_eigenvalues, expected_eigenvectors in zip(
-                    A_list,
-                    expected_eigenvalues_list,
-                    expected_eigenvectors_list,
-                    strict=True,
-                ):
-                    qr_config.eigenvectors_estimate = initialization_fn(A)
-                    estimated_eigenvalues, estimated_eigenvectors = (
-                        matrix_eigendecomposition(
-                            A,
-                            is_diagonal=False,
-                            eigendecomposition_config=qr_config,
-                        )
-                    )
-                    # Ensure that the signs of the eigenvectors are consistent.
-                    estimated_eigenvectors[
-                        :,
-                        expected_eigenvectors[0, :] / estimated_eigenvectors[0, :] < 0,
-                    ] *= -1
-                    torch.testing.assert_close(
-                        (expected_eigenvalues, expected_eigenvectors),
-                        (estimated_eigenvalues, estimated_eigenvectors),
-                        atol=atol,
-                        rtol=rtol,
-                    )
+            atol=atol,
+            rtol=rtol,
+        )
+
+    @parametrize(
+        "initialization_fn",
+        (
+            lambda A: torch.zeros_like(A),
+            lambda A: torch.eye(A.shape[0], dtype=A.dtype, device=A.device),
+            lambda A: matrix_eigendecomposition(A)[1],
+        ),
+    )
+    @parametrize(
+        "A, expected_eigenvalues, expected_eigenvectors",
+        (
+            # A diagonal matrix.
+            (
+                torch.tensor([[1.0, 0.0], [0.0, 4.0]]),
+                torch.tensor([1.0, 4.0]),
+                torch.tensor([[1.0, 0.0], [0.0, 1.0]]),
+            ),
+            # Non-diagonal matrix.
+            (
+                torch.tensor(
+                    [
+                        [1195.0, -944.0, -224.0],
+                        [-944.0, 746.0, 177.0],
+                        [-224.0, 177.0, 42.0],
+                    ]
+                ),
+                torch.tensor([2.9008677229e-03, 1.7424316704e-01, 1.9828229980e03]),
+                torch.tensor(
+                    [
+                        [0.0460073575, -0.6286827326, 0.7762997746],
+                        [-0.1751257628, -0.7701635957, -0.6133345366],
+                        [0.9834705591, -0.1077321917, -0.1455317289],
+                    ]
+                ),
+            ),
+        ),
+    )
+    def test_matrix_eigendecomposition_with_qr(
+        self,
+        A: Tensor,
+        expected_eigenvalues: Tensor,
+        expected_eigenvectors: Tensor,
+        initialization_fn: Callable[[Tensor], Tensor],
+    ) -> None:
+        atol = 2e-3
+        rtol = 1e-5
+
+        qr_config = QREigendecompositionConfig(max_iterations=10_000)
+        qr_config.eigenvectors_estimate = initialization_fn(A)
+        estimated_eigenvalues, estimated_eigenvectors = matrix_eigendecomposition(
+            A,
+            is_diagonal=False,
+            eigendecomposition_config=qr_config,
+        )
+
+        # Ensure that the signs of the eigenvectors are consistent.
+        estimated_eigenvectors[
+            :,
+            expected_eigenvectors[0, :] / estimated_eigenvectors[0, :] < 0,
+        ] *= -1
+        torch.testing.assert_close(
+            (expected_eigenvalues, expected_eigenvectors),
+            (estimated_eigenvalues, estimated_eigenvectors),
+            atol=atol,
+            rtol=rtol,
+        )
 
     def test_invalid_eigendecomposition_config(self) -> None:
         @dataclass
@@ -927,4 +840,21 @@ class MatrixEigendecompositionTest(unittest.TestCase):
             matrix_eigendecomposition,
             A=torch.tensor([[1.0, 0.0], [0.0, 4.0]]),
             eigendecomposition_config=NotSupportedEigendecompositionConfig(),
+        )
+
+
+class MatrixEigendecompositionDiagonalTest(unittest.TestCase):
+    def test_matrix_eigendecomposition(self) -> None:
+        A = torch.tensor([[1.0, 0.0], [0.0, 4.0]])
+        expected_eigenvalues, expected_eigenvectors = (
+            torch.tensor([1.0, 4.0]),
+            torch.tensor([[1.0, 0.0], [0.0, 1.0]]),
+        )
+
+        torch.testing.assert_close(
+            (expected_eigenvalues, expected_eigenvectors),
+            matrix_eigendecomposition(
+                A,
+                is_diagonal=True,
+            ),
         )


### PR DESCRIPTION
Summary: This diff simplifies the tests for distributed Shampoo by using the `parametrize` function from the `torch.testing._internal.common_utils` module. This allows for more efficient testing and reduces the amount of code duplication.

Differential Revision: D73086344


