### PR TITLE
Add 0D tensor into preconditioner list test cases

### DIFF
--- a/distributed_shampoo/shampoo_types.py
+++ b/distributed_shampoo/shampoo_types.py
@@ -107,7 +107,7 @@ class ShampooPreconditionerConfig(PreconditionerConfig):
         amortized_computation_config (RootInvConfig | EigendecompositionConfig): Configuration for the inverse-root computation. (Default: DefaultEigenConfig)
         num_tolerated_failed_amortized_computations (int): Number of failed amortized computations to tolerate before raising an error. (Default: 3)
         inverse_exponent_override (dict[int, dict[int, float]]): The inverse_exponent_override attribute is a dictionary that allows for customizing the inverse exponent used in the Shampoo preconditioner computation.
-            The keys of the dictionary represent the order of the tensor, and the values are dictionaries with dimension indices as keys and override values as values. All unspecified dimensions use a default exponent of 1/(2*o), where o is the order of the tensor. (Default: {})
+            The keys of the dictionary represent the order of the tensor, and the values are dictionaries with dimension indices as keys and override values as values. All unspecified dimensions use a default exponent of 1/(2*max(o,1)), where o is the order of the tensor. (Default: {})
 
             As an example, suppose inverse_exponent_override={2: {0: 0.5, 1: 0.2}, 3: {0: 0.0, 1: 0.25}}. In this case, all 1-D tensors will use the default exponent of 0.5 for preconditioning the first (and only) dimension. All 2-D tensors will be preconditioned with an exponent of 0.5 on the first dimension and 0.2 on the second dimension. All 3-D tensors will have the first dimension be preconditioned with an exponent of 0.5, the second dimension not preconditioned, and the third dimension preconditioned with the default exponent 0.1667.
             A visualization of this example can be seen below:

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -936,7 +936,7 @@ class ShampooPreconditionerList(
         return tuple(
             attrgetter(INVERSE_EXPONENT_OVERRIDE)(self._preconditioner_config)
             .get((order := len(dims)), {})
-            .get(d, 1 / (2 * order))
+            .get(d, 1 / (2 * max(order, 1)))
             != 0.0
             # Traverse through each dim of a block.
             for d in range(len(dims))
@@ -967,7 +967,7 @@ class ShampooPreconditionerList(
             1
             / attrgetter(INVERSE_EXPONENT_OVERRIDE)(self._preconditioner_config)
             .get((order := len(preconditioned_dims_selector)), {})
-            .get(k, 1 / (2 * order))
+            .get(k, 1 / (2 * max(order, 1)))
             # Traverse through each dim of a block that requires precondition.
             for k, should_precondition in enumerate(preconditioned_dims_selector)
             if should_precondition

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -178,6 +178,7 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
         return (
             self._params[0],
             *torch.split(self._params[1], 2, dim=0),
+            self._params[2],
         )
 
     def _instantiate_preconditioner_list(
@@ -195,10 +196,12 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
         self._params = (
             torch.tensor([1.0, 2.0]),
             torch.arange(6, dtype=torch.float).reshape(3, 2),
+            torch.tensor(1.0),  # a 0D tensor
         )
         self._state = {  # type: ignore[var-annotated]
             self._params[0]: {},
             self._params[1]: {},
+            self._params[2]: {},
         }
         # Because maximum_preconditioner_dim = 2, self._params[0] forms a block by itself,
         # and self._params[1] are split into two blocks.
@@ -215,6 +218,10 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
                 param=self._params[1],
                 composable_block_ids=(1, "block_1"),
             ),
+            BlockInfo(
+                param=self._params[2],
+                composable_block_ids=(2, "block_0"),
+            ),
         )
         super().setUp()
 
@@ -223,6 +230,7 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
             torch.tensor([1.0, 1.0]),
             torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
             torch.tensor([[5.0, 6.0]]),
+            torch.tensor(1.0),
         )
 
         self._test_update_preconditioners_and_precondition(
@@ -242,28 +250,33 @@ class AdagradPreconditionerListTest(PreconditionerListTest):
             ),
             masked_grad_lists=[grad_list],
             masked_expected_preconditioned_grad_list=torch._foreach_mul(
-                [torch.tensor(10.0), torch.tensor(10.0), torch.tensor(10.0)],
+                [
+                    torch.tensor(10.0),
+                    torch.tensor(10.0),
+                    torch.tensor(10.0),
+                    torch.tensor(10.0),
+                ],
                 torch._foreach_sign(grad_list),
             ),
         )
 
     def test_numel_list(self) -> None:
-        self.assertEqual(self._preconditioner_list.numel_list, (2, 4, 2))
+        self.assertEqual(self._preconditioner_list.numel_list, (2, 4, 2, 1))
 
     def test_dims_list(self) -> None:
         self.assertEqual(
             self._preconditioner_list.dims_list,
-            (torch.Size([2]), torch.Size([2, 2]), torch.Size([1, 2])),
+            (torch.Size([2]), torch.Size([2, 2]), torch.Size([1, 2]), torch.Size([])),
         )
 
     def test_num_bytes_list(self) -> None:
-        self.assertEqual(self._preconditioner_list.num_bytes_list, (8, 16, 8))
+        self.assertEqual(self._preconditioner_list.num_bytes_list, (8, 16, 8, 4))
 
     def test_numel(self) -> None:
-        self.assertEqual(self._preconditioner_list.numel(), 8)
+        self.assertEqual(self._preconditioner_list.numel(), 9)
 
     def test_num_bytes(self) -> None:
-        self.assertEqual(self._preconditioner_list.num_bytes(), 32)
+        self.assertEqual(self._preconditioner_list.num_bytes(), 36)
 
     def test_compress_preconditioner_list(self) -> None:
         self._test_compress_preconditioner_list(expected_compress_list_call_count=1)
@@ -394,6 +407,7 @@ class AbstractTest:
                     torch.tensor([invalid_value, invalid_value]),
                     torch.eye(2) / torch.tensor(2.0).sqrt(),
                     torch.tensor([[invalid_value, invalid_value]]),
+                    torch.tensor(invalid_value),
                 ),
                 step=torch.tensor(1),
                 perform_amortized_computation=True,
@@ -427,6 +441,7 @@ class AbstractTest:
                             torch.tensor([1.0, 0.0]),
                             torch.eye(2) / torch.tensor(2.0).sqrt(),
                             torch.tensor([[1.0, 0.0]]),
+                            torch.tensor(1.0),
                         ),
                         step=torch.tensor(1),
                         perform_amortized_computation=True,
@@ -446,6 +461,7 @@ class AbstractTest:
                             torch.tensor([1.0, 0.0]),
                             torch.eye(2) / torch.tensor(2.0).sqrt(),
                             torch.tensor([[1.0, 0.0]]),
+                            torch.tensor(1.0),
                         ),
                         step=torch.tensor(1),
                         perform_amortized_computation=True,
@@ -470,11 +486,13 @@ class AbstractTest:
                 torch.tensor([1.0, 0.0]),
                 torch.eye(2) / torch.tensor(2.0).sqrt(),
                 torch.tensor([[1.0, 0.0]]),
+                torch.tensor(1.0),
             )
             masked_grad_list = (
                 torch.tensor([0.0, 1.0]),
                 torch.eye(2) / torch.tensor(2.0).sqrt(),
                 torch.tensor([[0.0, 1.0]]),
+                torch.tensor(1.0),
             )
 
             # Number of calls to the amortized computation function per update.
@@ -668,16 +686,21 @@ class AbstractTest:
                     )
 
         def test_numel_list(self) -> None:
-            self.assertEqual(self._preconditioner_list.numel_list, (8, 16, 10))
+            self.assertEqual(self._preconditioner_list.numel_list, (8, 16, 10, 0))
 
         def test_dims_list(self) -> None:
             self.assertEqual(
                 self._preconditioner_list.dims_list,
-                (torch.Size([2]), torch.Size([2, 2]), torch.Size([1, 2])),
+                (
+                    torch.Size([2]),
+                    torch.Size([2, 2]),
+                    torch.Size([1, 2]),
+                    torch.Size([]),
+                ),
             )
 
         def test_num_bytes_list(self) -> None:
-            self.assertEqual(self._preconditioner_list.num_bytes_list, (48, 96, 60))
+            self.assertEqual(self._preconditioner_list.num_bytes_list, (48, 96, 60, 0))
 
         def test_numel(self) -> None:
             self.assertEqual(self._preconditioner_list.numel(), 34)
@@ -734,16 +757,24 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
             R = G1^T * G1 + G2^T * G2 = [[1, 0], [0, 1]]
             P = L^{-1/4} G2 R^{-1/4} = 2^{-1/4} * [[0, 1]] = 2^{-1/4} G2
 
+        (4) Tensor of Size 0
+            G1 = 3
+            G2 = 2
+
+            P = G2 = 2 because there is no preconditioner due to 0D tensor.
+
         """
         masked_grad_list1 = (
             torch.tensor([1.0, 0.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[1.0, 0.0]]),
+            torch.tensor(3.0),
         )
         masked_grad_list2 = (
             torch.tensor([0.0, 1.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0.0, 1.0]]),
+            torch.tensor(2.0),
         )
 
         masked_expected_preconditioned_grad_list = [
@@ -873,22 +904,31 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
             R = G1^T * G1 + G2^T * G2 = [[4, 0], [0, 4]]
             P = L^{-1/4} G2 R^{-1/4} = 8^{-1/4} G2 [[1/sqrt(2), 0], [0, 1/sqrt(2)]] = G2 / (sqrt(2 * sqrt(8)))
 
+        (4) Tensor of Size 0
+            G1 = 3
+            G2 = 2
+
+            P = G2 = 2 because there is no preconditioner due to 0D tensor.
+
         """
         masked_grad_list1 = (
             torch.tensor([4.0, 0.0]),
             torch.eye(2) * 3,
             torch.tensor([[2.0, 0.0]]),
+            torch.tensor(3.0),
         )
         masked_grad_list2 = (
             torch.tensor([0.0, 4.0]),
             torch.eye(2) * 4,
             torch.tensor([[0.0, 2.0]]),
+            torch.tensor(2.0),
         )
 
         masked_expected_preconditioned_grad_list = [
             torch.tensor([0.0, 1.0]),
             masked_grad_list2[1] / 5,
             masked_grad_list2[2] / math.sqrt(2 * math.sqrt(8)),
+            torch.tensor(2.0),
         ]
 
         # The default case where we do not ignore any dimensions.
@@ -948,6 +988,12 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
             R = G1^T * G1 + G2^T * G2 = [[1, 0], [0, 4]]
             P = L^{-1} G2 R^{-1} =  [[0, 0.1]]
 
+        (4) Tensor of Size 0
+            G1 = 3
+            G2 = 2
+
+            P = G2 = 2 because there is no preconditioner due to 0D tensor.
+
         """
 
         preconditioner_config = replace(
@@ -963,17 +1009,20 @@ class ShampooPreconditionerListTest(AbstractTest.BaseShampooPreconditionerListTe
             torch.tensor([1.0, 0.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[1.0, 0.0]]),
+            torch.tensor(3.0),
         )
         masked_grad_list2 = (
             torch.tensor([0.0, 2.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0.0, 2.0]]),
+            torch.tensor(2.0),
         )
 
         masked_expected_preconditioned_grad_list = (
             torch.tensor([0, 0.5]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0, 0.1]]),
+            torch.tensor(2.0),
         )
 
         self._test_update_preconditioners_and_precondition(
@@ -1060,22 +1109,32 @@ class EigenvalueCorrectedShampooPreconditionerListTest(
             E = G1^2 + (B_L G2 B_R)^2  # corrected eigenvalues
             P = B_L ((B_L G2 B_R) / sqrt(E + eps) B_R = G2 / sqrt(E + eps)
 
+        (4) Tensor of Size 0
+            G1 = 1
+            G2 = 2
+
+            E = G1^2 + G2^2            # identical to Adam on 0D tensors
+            P = G2 / (E + eps) = 2 / (5 + eps) ≈ 0.4
+
         """
         masked_grad_list1 = (
             torch.tensor([1.0, 0.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[1.0, 0.0]]),
+            torch.tensor(1.0),
         )
         masked_grad_list2 = (
             torch.tensor([0.0, 2.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0.0, 2.0]]),
+            torch.tensor(2.0),
         )
 
         masked_expected_preconditioned_grad_list = (
             torch.tensor([0.0, 1.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0.0, 1.0]]),
+            torch.tensor(2 / math.sqrt(5)),
         )
         self._test_update_preconditioners_and_precondition(
             preconditioner_list=self._instantiate_preconditioner_list(
@@ -1112,6 +1171,7 @@ class EigenvalueCorrectedShampooPreconditionerListTest(
             torch.tensor([0.0, 1.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0.0, 1.0]]),
+            torch.tensor(2 / math.sqrt(5)),
         )
         # Fix scaling due to EMA.
         torch._foreach_div_(
@@ -1211,6 +1271,13 @@ class EigenvalueCorrectedShampooPreconditionerListTest(
             E = G1^2 + (B_L G2 B_R)^2  # corrected eigenvalues
             P = B_L ((B_L G2 B_R) / (E + eps)) B_R = G2 / (E + eps) ≈ [[0, 0.5]]
 
+        (4) Tensor of Size 0
+            G1 = 1
+            G2 = 2
+
+            E = G1^2 + G2^2            # identical to Adam on 0D tensors
+            P = G2 / (E + eps) = 2 / (5 + eps) ≈ 0.4
+
         """
 
         preconditioner_config = EigenvalueCorrectedShampooPreconditionerConfig(
@@ -1221,17 +1288,20 @@ class EigenvalueCorrectedShampooPreconditionerListTest(
             torch.tensor([1.0, 0.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[1.0, 0.0]]),
+            torch.tensor(1.0),
         )
         masked_grad_list2 = (
             torch.tensor([0.0, 2.0]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0.0, 2.0]]),
+            torch.tensor(2.0),
         )
 
         masked_expected_preconditioned_grad_list = (
             torch.tensor([0, 0.5]),
             torch.eye(2) / torch.tensor(2.0).sqrt(),
             torch.tensor([[0, 0.5]]),
+            torch.tensor(0.4),
         )
 
         self._test_update_preconditioners_and_precondition(


### PR DESCRIPTION
Summary: This diff adds test cases for adding 0D tensors into the preconditioner list in Shampoo optimizer. The changes include adding a 0D tensor to the list of parameters and modifying the code to handle the 0D tensor.

Differential Revision: D73128069
