### PR TITLE
Fix comments inconsistencies on return type and raises

### DIFF
--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -252,7 +252,7 @@ class AdagradPreconditionerList(PreconditionerList):
             masked_grad_list (tuple[Tensor, ...]): A tuple of gradients with None values removed.
 
         Returns:
-            tuple[Tensor, ...]: A tuple of preconditioned gradients.
+            preconditioned_grads (tuple[Tensor, ...]): A list of preconditioned gradients.
         """
         with profiler.record_function(
             f"## {self.__class__.__name__}:{self.precondition.__name__} ##"
@@ -1180,7 +1180,7 @@ class EigendecomposedShampooPreconditionerList(
             masked_grad_list (tuple[Tensor, ...]): A list of gradients with their corresponding masks.
 
         Returns:
-            tuple[Tensor, ...]: A list of preconditioned gradients.
+            preconditioned_grads (tuple[Tensor, ...]): A list of preconditioned gradients.
         """
         with profiler.record_function(
             f"## {self.__class__.__name__}:{self.precondition.__name__} ##"


### PR DESCRIPTION
Summary: This diff fixes inconsistencies in the return types and raises in the comments of the `shampoo_preconditioner_list.py` and `matrix_functions.py` files. Clean this up before Runa's incoming changes for metrics logging.

Differential Revision: D73143799


