### PR TITLE
Fix the bug skipping step if no gradients

### DIFF
--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -215,23 +215,6 @@ class DistributedShampooTest(unittest.TestCase):
 
         self.assertEqual(self._optimizer.step(closure=closure), 1.0)
 
-    def test_step_with_empty_grad_list(self) -> None:
-        # Because the grad_list is empty, after taking five steps, the internal step should be 0.
-        for _ in range(5):
-            self._optimizer.zero_grad()
-            self._optimizer.step()
-
-        actual_step = self._optimizer.distributed_state_dict(
-            key_to_param=self._model.named_parameters(),
-            save_param_groups=True,
-        )["state"]["0.weight"]['["step"]']
-        torch.testing.assert_close(
-            actual_step,
-            torch.as_tensor(0),
-            rtol=0,
-            atol=0,
-        )
-
 
 class AbstractTest:
     class ShampooDistributedStateDictTestBase(abc.ABC, unittest.TestCase):

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
@@ -190,6 +190,36 @@ class ShampooFSDPDistributorTest(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
+    def test_all_ranks_with_no_grads(self) -> None:
+        fsdp_config = FSDPShampooConfig(param_to_metadata={})
+        model, loss, data, target = ShampooFSDPDistributorTest._construct_model(
+            distributed_config=fsdp_config,
+            device=torch.device("cuda"),
+        )
+        optimizer = ShampooFSDPDistributorTest._shampoo_optim_factory(
+            distributed_config=fsdp_config,
+        )(model.parameters())
+
+        num_steps = 3
+        for _ in range(num_steps):
+            objective = loss(model(data), target)
+            objective.backward()
+
+            # Experiment setup: all ranks get no gradients.
+            optimizer.zero_grad()
+
+            optimizer.step()
+
+        assert isinstance(optimizer, DistributedShampoo)
+        # For each rank, no matter getting gradients or not, the step should be updated.
+        self.assertEqual(
+            optimizer.distributed_state_dict(key_to_param=model.named_parameters())[
+                "state"
+            ]["_fsdp_wrapped_module.linear_layers.0.weight"]['["step"]'].item(),
+            num_steps,
+        )
+
+    @skip_if_lt_x_gpu(2)
     def test_fsdp_shampoo_against_default_shampoo(self) -> None:
         fsdp_config = FSDPShampooConfig(param_to_metadata={})
         ShampooFSDPDistributorTest._test_two_configs(

--- a/distributed_shampoo/utils/shampoo_distributor.py
+++ b/distributed_shampoo/utils/shampoo_distributor.py
@@ -273,12 +273,20 @@ class Distributor(DistributorInterface):
 
         Args:
             masked_blocked_search_directions (tuple[Tensor, ...]): Search directions for each local blocked parameter.
+            This tuple might be empty if the parameters are not receiving gradients.
 
         """
-        torch._foreach_add_(
-            self._local_masked_blocked_params,
-            masked_blocked_search_directions,
-        )
+        assert (
+            len(masked_blocked_search_directions)
+            == len(self._local_masked_blocked_params)
+        ), f"Expected {len(masked_blocked_search_directions)=} to be equal to {len(self._local_masked_blocked_params)=}."
+
+        # torch._foreach only accepts non-empty list
+        if masked_blocked_search_directions:
+            torch._foreach_add_(
+                self._local_masked_blocked_params,
+                masked_blocked_search_directions,
+            )
 
     @torch.no_grad()
     def _construct_local_block_info_list(

--- a/distributed_shampoo/utils/shampoo_fsdp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_fsdp_distributor.py
@@ -78,12 +78,20 @@ class FSDPDistributor(DistributorInterface):
 
         Args:
             masked_blocked_search_directions (tuple[Tensor, ...]): Search directions for each local blocked parameter.
+            This tuple might be empty if the parameters are not receiving gradients.
 
         """
-        torch._foreach_add_(
-            self._local_masked_blocked_params,
-            masked_blocked_search_directions,
-        )
+        assert (
+            len(masked_blocked_search_directions)
+            == len(self._local_masked_blocked_params)
+        ), f"Expected {len(masked_blocked_search_directions)=} to be equal to {len(self._local_masked_blocked_params)=}."
+
+        # torch._foreach only accepts non-empty list
+        if masked_blocked_search_directions:
+            torch._foreach_add_(
+                self._local_masked_blocked_params,
+                masked_blocked_search_directions,
+            )
 
     def _construct_composable_block_ids(
         self,

--- a/distributed_shampoo/utils/shampoo_hsdp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hsdp_distributor.py
@@ -250,45 +250,59 @@ class HSDPDistributor(DistributorInterface):
         Args:
             masked_blocked_search_directions (tuple[Tensor, ...]): Search directions for each local blocked parameter.
 
-        See the comment in the parent class for details.
-
         """
         if self._communicate_params:
-            # Perform your update to your local masked parameters and copy into buffers.
-            torch._foreach_add_(
-                self._local_masked_blocked_params,
-                masked_blocked_search_directions,
-            )
-            torch._foreach_copy_(
-                self._local_masked_dist_blocked_buffers,
-                self._local_masked_blocked_params,
-            )
+            assert (
+                len(self._local_masked_blocked_params)
+                == len(masked_blocked_search_directions)
+            ), f"Expected {len(self._local_masked_blocked_params)=} to be equal to {len(masked_blocked_search_directions)=}."
+
+            # torch._foreach only accepts non-empty list
+            if masked_blocked_search_directions:
+                # Perform your update to your local masked parameters and copy into buffers.
+                torch._foreach_add_(
+                    self._local_masked_blocked_params,
+                    masked_blocked_search_directions,
+                )
+                torch._foreach_copy_(
+                    self._local_masked_dist_blocked_buffers,
+                    self._local_masked_blocked_params,
+                )
 
             self.all_gather_into_tensor()
 
-            # Copy updated blocked params in global_masked_dist_blocked_buffers
-            # into global_masked_blocked_params.
-            torch._foreach_copy_(
-                self._global_masked_blocked_params,
-                self._global_masked_dist_blocked_buffers,
-            )
+            # torch._foreach only accepts non-empty list
+            if self._global_masked_blocked_params:
+                # Copy updated blocked params in global_masked_dist_blocked_buffers into global_masked_blocked_params.
+                torch._foreach_copy_(
+                    self._global_masked_blocked_params,
+                    self._global_masked_dist_blocked_buffers,
+                )
 
         else:
-            # Search directions multiplied by alpha are distributed.
-            # Copy the local search directions to the communication buffer.
-            torch._foreach_copy_(
-                self._local_masked_dist_blocked_buffers,
-                masked_blocked_search_directions,
-            )
+            assert (
+                len(self._local_masked_dist_blocked_buffers)
+                == len(masked_blocked_search_directions)
+            ), f"Expected {len(self._local_masked_dist_blocked_buffers)=} to be equal to {len(masked_blocked_search_directions)=}."
+
+            # torch._foreach only accepts non-empty list
+            if masked_blocked_search_directions:
+                # Search directions multiplied by alpha are distributed.
+                # Copy the local search directions to the communication buffer.
+                torch._foreach_copy_(
+                    self._local_masked_dist_blocked_buffers,
+                    masked_blocked_search_directions,
+                )
 
             self.all_gather_into_tensor()
 
-            # Add search directions in global_masked_dist_blocked_buffers
-            # to global_masked_blocked_params.
-            torch._foreach_add_(
-                self._global_masked_blocked_params,
-                self._global_masked_dist_blocked_buffers,
-            )
+            # torch._foreach only accepts non-empty list
+            if self._global_masked_blocked_params:
+                # Add search directions in global_masked_dist_blocked_buffers to global_masked_blocked_params.
+                torch._foreach_add_(
+                    self._global_masked_blocked_params,
+                    self._global_masked_dist_blocked_buffers,
+                )
 
     def _construct_composable_block_ids(
         self,

--- a/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
@@ -254,45 +254,59 @@ class HybridShardDistributor(DistributorInterface):
         Args:
             masked_blocked_search_directions (tuple[Tensor, ...]): Search directions for each local blocked parameter.
 
-        See the comment in the parent class for details.
-
         """
         if self._communicate_params:
-            # Perform your update to your local masked parameters and copy into buffers.
-            torch._foreach_add_(
-                self._local_masked_blocked_params,
-                masked_blocked_search_directions,
-            )
-            torch._foreach_copy_(
-                self._local_masked_dist_blocked_buffers,
-                self._local_masked_blocked_params,
-            )
+            assert (
+                len(self._local_masked_blocked_params)
+                == len(masked_blocked_search_directions)
+            ), f"Expected {len(self._local_masked_blocked_params)=} to be equal to {len(masked_blocked_search_directions)=}."
+
+            # torch._foreach only accepts non-empty list
+            if masked_blocked_search_directions:
+                # Perform your update to your local masked parameters and copy into buffers.
+                torch._foreach_add_(
+                    self._local_masked_blocked_params,
+                    masked_blocked_search_directions,
+                )
+                torch._foreach_copy_(
+                    self._local_masked_dist_blocked_buffers,
+                    self._local_masked_blocked_params,
+                )
 
             self.all_gather_into_tensor()
 
-            # Copy updated blocked params in global_masked_dist_blocked_buffers
-            # into global_masked_blocked_params.
-            torch._foreach_copy_(
-                self._global_masked_blocked_params,
-                self._global_masked_dist_blocked_buffers,
-            )
+            # torch._foreach only accepts non-empty list
+            if self._global_masked_blocked_params:
+                # Copy updated blocked params in global_masked_dist_blocked_buffers into global_masked_blocked_params.
+                torch._foreach_copy_(
+                    self._global_masked_blocked_params,
+                    self._global_masked_dist_blocked_buffers,
+                )
 
         else:
-            # Search directions multiplied by alpha are distributed.
-            # Copy the local search directions to the communication buffer.
-            torch._foreach_copy_(
-                self._local_masked_dist_blocked_buffers,
-                masked_blocked_search_directions,
-            )
+            assert (
+                len(self._local_masked_dist_blocked_buffers)
+                == len(masked_blocked_search_directions)
+            ), f"Expected {len(self._local_masked_dist_blocked_buffers)=} to be equal to {len(masked_blocked_search_directions)=}."
+
+            # torch._foreach only accepts non-empty list
+            if masked_blocked_search_directions:
+                # Search directions multiplied by alpha are distributed.
+                # Copy the local search directions to the communication buffer.
+                torch._foreach_copy_(
+                    self._local_masked_dist_blocked_buffers,
+                    masked_blocked_search_directions,
+                )
 
             self.all_gather_into_tensor()
 
-            # Add search directions in global_masked_dist_blocked_buffers
-            # to global_masked_blocked_params.
-            torch._foreach_add_(
-                self._global_masked_blocked_params,
-                self._global_masked_dist_blocked_buffers,
-            )
+            # torch._foreach only accepts non-empty list
+            if self._global_masked_blocked_params:
+                # Add search directions in global_masked_dist_blocked_buffers to global_masked_blocked_params.
+                torch._foreach_add_(
+                    self._global_masked_blocked_params,
+                    self._global_masked_dist_blocked_buffers,
+                )
 
     def _construct_composable_block_ids(
         self,


### PR DESCRIPTION
Summary:
Reported by @wz337, this bug skips the `Distributor.update_params()` for ranks without gradients. Following are the known symptoms:
1. DDP/HSDP1/HSDP2 Shampoos might hang indefinitely at `torch.distributed.all_gather_into_tensor()` due to ranks without gradients won't join.
2. Ranks without gradients in FSDP1/FSDP2 Shampoos might have inconstent `step` values with others; this affects the timings of preconditioner computations.

To solve this, this diff removes the skipping logic and add guards on `torch._foreach_*` functions (suggested by @anana10c) due to its inabilities operating on empty lists.

Differential Revision: D73223132


