### PR TITLE
Refactor QR iterations and simplify change of basis code path

### DIFF
--- a/distributed_shampoo/utils/shampoo_utils.py
+++ b/distributed_shampoo/utils/shampoo_utils.py
@@ -8,7 +8,6 @@ LICENSE file in the root directory of this source tree.
 """
 
 import heapq
-import math
 import operator
 from collections.abc import Callable, Iterator, Sequence
 from functools import partial, reduce

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -277,16 +277,19 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
         # Disable the abstract methods check from the interface so it is possible to instantiate BaseShampooPreconditionerList.
         BaseShampooPreconditionerList.__abstractmethods__ = frozenset()
 
-        with mock.patch.object(
-            # Mock compress_list() to enable the instantiation of BaseShampooPreconditionerList.
-            shampoo_preconditioner_list,
-            "compress_list",
-            return_value=(True,) * max(param.dim(), 1),
-        ) as mock_compress_list, mock.patch.object(
-            # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
-            BaseShampooPreconditionerList,
-            "_update_factor_matrices",
-        ) as mock_update_factor_matrices:
+        with (
+            mock.patch.object(
+                # Mock compress_list() to enable the instantiation of BaseShampooPreconditionerList.
+                shampoo_preconditioner_list,
+                "compress_list",
+                return_value=(True,) * max(param.dim(), 1),
+            ) as mock_compress_list,
+            mock.patch.object(
+                # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
+                BaseShampooPreconditionerList,
+                "_update_factor_matrices",
+            ) as mock_update_factor_matrices,
+        ):
             # Test the abstract methods _create_preconditioned_dims_selector(), _create_kronecker_factors_state_for_block(), _create_kronecker_factors_list(), and _get_inverse_roots_from_override().
             preconditioner_list = BaseShampooPreconditionerList(  # type: ignore
                 block_list=(param,),
@@ -493,25 +496,27 @@ class AbstractTest:
             )
             all_fail = (fail,) * NUM_AMORTIZED_COMPUTATION_CALLS
             all_success = (success,) * NUM_AMORTIZED_COMPUTATION_CALLS
-            with mock.patch.object(
-                shampoo_preconditioner_list,
-                self._amortized_computation_properties.amortized_computation_function_name,
-                # Note that the cases causally depend on each other.
-                side_effect=[
-                    # Case 1: amortized computation fails less often than tolerance.
-                    *all_but_one_fail,  # Success for a single Kronecker factor is not enough to reset counter.
-                    # Case 2: amortized computation fails exactly as often as tolerance (3).
-                    *all_fail,
-                    *all_fail,
-                    # Case 3: amortized computation succeeds after tolerance hit (counter is reset).
-                    *all_success,
-                    # Case 4: amortized computation fails more often than tolerance.
-                    *all_fail,
-                    *all_fail,
-                    *all_fail,
-                    fail,  # One failure is enough to raise an exception in this case.
-                ],
-            ) as mock_amortized_computation:
+            with (
+                mock.patch.object(
+                    shampoo_preconditioner_list,
+                    self._amortized_computation_properties.amortized_computation_function_name,
+                    # Note that the cases causally depend on each other.
+                    side_effect=[
+                        # Case 1: amortized computation fails less often than tolerance.
+                        *all_but_one_fail,  # Success for a single Kronecker factor is not enough to reset counter.
+                        # Case 2: amortized computation fails exactly as often as tolerance (3).
+                        *all_fail,
+                        *all_fail,
+                        # Case 3: amortized computation succeeds after tolerance hit (counter is reset).
+                        *all_success,
+                        # Case 4: amortized computation fails more often than tolerance.
+                        *all_fail,
+                        *all_fail,
+                        *all_fail,
+                        fail,  # One failure is enough to raise an exception in this case.
+                    ],
+                ) as mock_amortized_computation
+            ):
                 # Accumulate factor matrices for valid amortized computation.
                 self._preconditioner_list.update_preconditioners(
                     masked_grad_list=masked_grad_list0,

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -287,8 +287,8 @@ def _eigh_eigenvalue_decomposition(
     return L.to(device=current_device), Q.to(device=current_device, dtype=A.dtype)
 
 
-def _estimated_eigenvalues_criterion_below_or_equal_tolerance(
-    estimated_eigenvalues: Tensor, tolerance: float
+def _eigenvalues_estimate_criterion_below_or_equal_tolerance(
+    eigenvalues_estimate: Tensor, tolerance: float
 ) -> bool:
     """Evaluates if a criterion using estimated eigenvalues is below or equal to the tolerance.
 
@@ -302,15 +302,15 @@ def _estimated_eigenvalues_criterion_below_or_equal_tolerance(
     Hence, the two relative errors are also equivalent: ||A - A'||_F / ||A||_F = ||B - diag(B)||_F / ||B||_F.
 
     Args:
-        estimated_eigenvalues (Tensor): The estimated eigenvalues.
+        eigenvalues_estimate (Tensor): The estimated eigenvalues.
         tolerance (float): The tolerance for the criterion.
 
     Returns:
         is_below_tolerance (bool): True if the criterion is below or equal to the tolerance, False otherwise.
 
     """
-    norm = torch.linalg.norm(estimated_eigenvalues)
-    diagonal_norm = torch.linalg.norm(estimated_eigenvalues.diag())
+    norm = torch.linalg.norm(eigenvalues_estimate)
+    diagonal_norm = torch.linalg.norm(eigenvalues_estimate.diag())
     off_diagonal_norm = torch.sqrt(norm**2 - diagonal_norm**2)
     return bool(off_diagonal_norm <= tolerance * norm)
 
@@ -323,9 +323,7 @@ def _qr_algorithm(
 ) -> tuple[Tensor, Tensor]:
     """Approximately compute the eigendecomposition of a symmetric matrix by performing the QR algorithm.
 
-    Given an initial estimate of the eigenvectors Q of matrix A, a power iteration and a QR decomposition is performed each iteration, i.e. Q, _ <- QR(A @ Q).
-    When the initial estimate is the zero matrix, the eigendecomposition is computed using _eigh_eigenvalue_decomposition.
-
+    Given an initial estimate of the eigenvectors Q of matrix A, QR iterations are performed until the criterion based on the estimated eigenvalues is below or equal to the specified tolerance or until the maximum number of iterations is reached.
     Note that if the criterion based on the estimated eigenvalues is already below or equal to the tolerance given the initial eigenvectors_estimate, the QR iterations will be skipped.
 
     Args:
@@ -336,16 +334,13 @@ def _qr_algorithm(
             (Default: 0.01)
 
     Returns:
-        estimated_eigenvalues (Tensor): The estimated eigenvalues of the input matrix A.
-        estimated_eigenvectors (Tensor): The estimated eigenvectors of the input matrix A.
+        eigenvalues_estimate (Tensor): The estimated eigenvalues of the input matrix A.
+        eigenvectors_estimate (Tensor): The estimated eigenvectors of the input matrix A.
 
     Raises:
         AssertionError: If the data types of Q and A do not match.
 
     """
-    if not eigenvectors_estimate.any():
-        return _eigh_eigenvalue_decomposition(A)
-
     # Perform orthogonal/simultaneous iterations (QR algorithm).
     Q = eigenvectors_estimate
 
@@ -354,25 +349,25 @@ def _qr_algorithm(
         Q.dtype == A.dtype
     ), f"Q and A must have the same dtype! {Q.dtype=} {A.dtype=}"
 
-    estimated_eigenvalues = Q.T @ A @ Q
+    eigenvalues_estimate = Q.T @ A @ Q
     iteration = 0
     # NOTE: This will skip the QR iterations if the criterion is already below or equal to the tolerance given the initial eigenvectors_estimate.
     while (
         iteration < max_iterations
-        and not _estimated_eigenvalues_criterion_below_or_equal_tolerance(
-            estimated_eigenvalues, tolerance
+        and not _eigenvalues_estimate_criterion_below_or_equal_tolerance(
+            eigenvalues_estimate, tolerance
         )
     ):
-        power_iteration = A @ Q
-        Q = torch.linalg.qr(power_iteration).Q
+        Q, R = torch.linalg.qr(eigenvalues_estimate)
+        eigenvalues_estimate = R @ Q
+        eigenvectors_estimate = eigenvectors_estimate @ Q
         iteration += 1
-        estimated_eigenvalues = Q.T @ A @ Q
 
     # Ensure consistent ordering of estimated eigenvalues and eigenvectors.
-    estimated_eigenvalues, indices = estimated_eigenvalues.diag().sort(stable=True)
-    Q = Q[:, indices]
+    eigenvalues_estimate, indices = eigenvalues_estimate.diag().sort(stable=True)
+    eigenvectors_estimate = eigenvectors_estimate[:, indices]
 
-    return estimated_eigenvalues, Q
+    return eigenvalues_estimate, eigenvectors_estimate
 
 
 def _matrix_inverse_root_eigen(

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -206,19 +206,22 @@ class MatrixInverseRootTest(unittest.TestCase):
     ) -> None:
         A = torch.tensor([[1.0, 0.0], [0.0, 4.0]])
         root = Fraction(4)
-        with mock.patch.object(
-            matrix_functions,
-            implementation,
-            return_value=(
-                None,
-                None,
-                NewtonConvergenceFlag.REACHED_MAX_ITERS,
-                None,
-                None,
+        with (
+            mock.patch.object(
+                matrix_functions,
+                implementation,
+                return_value=(
+                    None,
+                    None,
+                    NewtonConvergenceFlag.REACHED_MAX_ITERS,
+                    None,
+                    None,
+                ),
             ),
-        ), self.assertLogs(
-            level="WARNING",
-        ) as cm:
+            self.assertLogs(
+                level="WARNING",
+            ) as cm,
+        ):
             matrix_inverse_root(
                 A=A,
                 root=root,
@@ -763,7 +766,6 @@ class MatrixEigendecompositionTest(unittest.TestCase):
     @parametrize(
         "initialization_fn",
         (
-            lambda A: torch.zeros_like(A),
             lambda A: torch.eye(A.shape[0], dtype=A.dtype, device=A.device),
             lambda A: matrix_eigendecomposition(A)[1],
         ),
@@ -809,20 +811,20 @@ class MatrixEigendecompositionTest(unittest.TestCase):
 
         qr_config = QREigendecompositionConfig(max_iterations=10_000)
         qr_config.eigenvectors_estimate = initialization_fn(A)
-        estimated_eigenvalues, estimated_eigenvectors = matrix_eigendecomposition(
+        eigenvalues_estimate, eigenvectors_estimate = matrix_eigendecomposition(
             A,
             is_diagonal=False,
             eigendecomposition_config=qr_config,
         )
 
         # Ensure that the signs of the eigenvectors are consistent.
-        estimated_eigenvectors[
+        eigenvectors_estimate[
             :,
-            expected_eigenvectors[0, :] / estimated_eigenvectors[0, :] < 0,
+            expected_eigenvectors[0, :] / eigenvectors_estimate[0, :] < 0,
         ] *= -1
         torch.testing.assert_close(
             (expected_eigenvalues, expected_eigenvectors),
-            (estimated_eigenvalues, estimated_eigenvectors),
+            (eigenvalues_estimate, eigenvectors_estimate),
             atol=atol,
             rtol=rtol,
         )


### PR DESCRIPTION
- Rewrite QR iterations which results in one less matrix product per iteration (2 instead of 3 per iteration).
- Removes the eigendecomposition with `eigh` when the `eigenvectors_estimate` for `_qr_algorithm` is a zero matrix (it should never be a zero matrix since we initialise with `eye` now).
- Simplifies the code paths for changing the basis of the gradient because we do not have to check whether the eigenvectors exist (`_precondition_grad` is a no-op when there are no eigenvectors) or if they are all-zero (again, because we initialise with `eye` now).