### PR TITLE
Fix `CoupledHigherOrderConfig` initialization in `trainer_utils.py`

### DIFF
--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -505,7 +505,9 @@ def instantiate_preconditioner_config(
         == PreconditionerComputationType.COUPLED_HIGHER_ORDER_ROOT_INV
     ):
         return ShampooPreconditionerConfig(
-            amortized_computation_config=CoupledHigherOrderConfig(),
+            amortized_computation_config=CoupledHigherOrderConfig(
+                rel_epsilon=0.0, abs_epsilon=0.0
+            ),
         )
     elif (
         preconditioner_computation_type


### PR DESCRIPTION
Summary: Fix the CI errors shown due to https://github.com/facebookresearch/optimizers/commit/b3ac8996516dd6d39b7c78e22e188c5d5f819917.

Differential Revision: D73300922


