### PR TITLE
Refactor `BaseShampooKroneckerFactors` related fields

### DIFF
--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -297,11 +297,14 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
             "compress_list",
             return_value=(True,) * max(param.dim(), 1),
         ) as mock_compress_list, mock.patch.object(
+            BaseShampooPreconditionerList,
+            "_create_kronecker_factors_state",
+        ) as mock_create_kronecker_factor_state, mock.patch.object(
             # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
             BaseShampooPreconditionerList,
             "_update_factor_matrices",
         ) as mock_update_factor_matrices:
-            # Test the abstract methods _create_preconditioned_dims_selector(), _create_kronecker_factors_state_for_block(), _create_kronecker_factors_list(), and _get_inverse_roots_from_override().
+            # Test the abstract methods _create_preconditioned_dims_selector() and _get_inverse_roots_from_override().
             preconditioner_list = methodcaller(
                 "__call__",
                 block_list=(param,),
@@ -324,6 +327,7 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
             )
 
             mock_compress_list.assert_called_once()
+            mock_create_kronecker_factor_state.assert_called_once()
             mock_update_factor_matrices.assert_called_once()
 
 


### PR DESCRIPTION
Summary: Instead of letting each `BaseShampooPreconditionerList` implement abstract methods to instantiate `BaseShampooKroneckerFactors` and its subclasses, this is done by each class's own classmethod `from_block()` instead. Doing this reduce the interfaces need of `BasedShampooPreconditionerList` related classes, and make the uses of `BaseShampooKroneckerFactors` more flexible.

Differential Revision: D73704487


