### PR TITLE
Fix mypy type checker complain

### DIFF
--- a/distributed_shampoo/tests/shampoo_types_test.py
+++ b/distributed_shampoo/tests/shampoo_types_test.py
@@ -68,7 +68,8 @@ class RMSpropGraftingConfigSubclassesTest(unittest.TestCase):
 @instantiate_parametrized_tests
 class PreconditionerConfigSubclassesTest(unittest.TestCase):
     subclasses_types: list[type[PreconditionerConfig]] = get_all_subclasses(
-        PreconditionerConfig, include_cls_self=False
+        PreconditionerConfig,  # type: ignore[type-abstract]
+        include_cls_self=False,
     )
 
     # Not testing for the base class PreconditionerConfig because it is an abstract class.


### PR DESCRIPTION
Summary: Based on https://github.com/facebookresearch/optimizers/actions/runs/14764993105/job/41454351824, `mypy` is complaing about `PreconditionerConfig` is abstract.

Differential Revision: D73957301


