### PR TITLE
Fix mypy type checker complain

### DIFF
--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -66,7 +66,7 @@ def _get_function_args_from_config(
     """
     return {
         field.name: getattr(config, field.name)
-        for field in fields(config)
+        for field in fields(config)  # type: ignore[arg-type]
         if field.name in inspect.getfullargspec(func).args
     }
 


### PR DESCRIPTION
Summary: Based on https://github.com/facebookresearch/optimizers/actions/runs/14767696081/job/41462232331, this fix `mypy`'s complain on `arg-type` mismatched.

Differential Revision: D73972632


