### PR TITLE
Add unit tests for matrix inverse root computation using larger epsilon

### DIFF
--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -1432,6 +1432,7 @@ class EigendecomposedShampooPreconditionerList(
                                 A=bias_corrected_factor_matrix,
                                 eigendecomposition_config=eigendecomposition_config,
                                 is_diagonal=False,
+                                epsilon=self._epsilon,
                             )
                         )
                         computed_eigenvalues.to(dtype=factor_matrix_eigenvalues.dtype)
@@ -1681,6 +1682,7 @@ class EigenvalueCorrectedShampooPreconditionerList(
                             A=factor_matrix,
                             eigendecomposition_config=eigendecomposition_config,
                             is_diagonal=False,
+                            epsilon=self._epsilon,
                         )[1].to(dtype=factor_matrix_eigenvectors.dtype)
                         # Add success to success tracker.
                         success_tracker &= True

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -886,6 +886,99 @@ class RootInvShampooPreconditionerListTest(
             ),
         )
 
+    def test_update_preconditioners_and_precondition_with_epsilon(self) -> None:
+        """
+        We provide examples where we deliberately choose a large epsilon. This is to ensure that
+        the matrix inverse computation behaves as expected. Below we update the preconditioners twice
+        for 4 different blocks and check if the preconditioned gradients are as expected. When
+        performing the inverse computation, epsilon is chosen to be 80 in (L + epsilon * I) and
+        (R + epsilon * I).
+
+        G_{ij}: at the i-th step, the gradient for the j-th block. For example,
+        G12 is the gradient for the second block, at the first step.
+
+        epsilon = 80.0
+
+        Gradients for block 1: (no right preconditioner)
+        (1) 1D Tensor of Size 2
+            G11 = [1, 0]^T
+            G21 = [0, 1]^T
+
+            L = G11 * G11^T + G21 * G21^T = [[1, 0], [0, 1]]
+            P = (L + epsilon * I)^{-1/2} G21 = [[81, 0], [0, 81]]^{-1/2} [0, 1]^T
+              = [0, 1/9]^T.
+
+        Gradients for block 2: (both left and right preconditioner)
+        (2) Tensor of Size 2 x 2
+            G12 = [[1, 0], [0, 1]] / sqrt(2)
+            G22 = [[1, 0], [0, 1]] / sqrt(2)
+
+            L = G12 * G12^T + G22 * G22^T = [[1, 0], [0, 1]]
+            R = G12^T * G12 + G22^T * G22 = [[1, 0], [0, 1]]
+            P = (L + epsilon * I)^{-1/4} G22 (R + epsilon * I)^{-1/4}
+              = [[1/3, 0], [0, 1/3]] * G22 * [[1/3, 0], [0, 1/3]] = I / (9 * sqrt(2))
+
+        Gradients for block 3: (both left and right preconditioner)
+        (3) Tensor of Size 1 x 2
+            G13 = [[1, 0]]
+            G23 = [[0, 1]]
+
+            L = G13 * G13^T + G23 * G23^T = I
+            R = G13^T * G13 + G23^T * G23 = 2
+            P = (L + epsilon * I)^{-1/4} G22 (R + epsilon * I)^{-1/4}
+              = [[1/3, 0], [0, 1/3]] * G22 * (80 + 2)^{-1/4} =
+              = [[0.0, 1.0/3.0 * 82.0 ** (-1/4)]]
+
+        Gradients for block 4: (no preconditioner)
+        (4) Tensor of Size 0
+            G14 = 1
+            G24 = 1
+
+            No preconditioner is applied. Expected gradient is 1.
+
+        """
+
+        epsilon = 80.0
+
+        # Blocked gradients at the first step: masked_grad_list1 = (G11, G12, G13, G14)
+        masked_grad_list1 = (
+            torch.tensor([1.0, 0.0]),
+            torch.eye(2) / math.sqrt(2),
+            torch.tensor([[1.0, 0.0]]),
+            torch.tensor(1.0),
+        )
+
+        # Blocked gradients at the second step: masked_grad_list2 = (G21, G22, G23, G24)
+        masked_grad_list2 = (
+            torch.tensor([0.0, 1.0]),
+            torch.eye(2) / math.sqrt(2),
+            torch.tensor([[0.0, 1.0]]),
+            torch.tensor(1.0),
+        )
+
+        # Manually apply the preconditioners to the gradients at the second step (masked_grad_list2) with epsilon.
+        # The result is stored in masked_expected_preconditioned_grad_list.
+
+        masked_expected_preconditioned_grad_list = (
+            torch.tensor([0.0, 1.0 / 9.0]),
+            torch.eye(2) / (9 * math.sqrt(2)),
+            torch.tensor([[0.0, 1.0 / 3.0 * 82.0 ** (-1 / 4)]]),
+            torch.tensor(1.0),
+        )
+
+        # Apply preconditioner to the last step (masked_grad_list2) with epsilon. The result should be the same as the expected preconditioned grad list.
+        self._test_update_preconditioners_and_precondition(
+            preconditioner_list=self._instantiate_preconditioner_list(
+                beta2=1.0,
+                use_bias_correction=True,
+                epsilon=epsilon,
+            ),
+            masked_grad_lists=[masked_grad_list1, masked_grad_list2],
+            masked_expected_preconditioned_grad_list=tuple(
+                masked_expected_preconditioned_grad_list
+            ),
+        )
+
     def test_update_preconditioners_and_precondition_with_dims_ignored(self) -> None:
         """
 

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -234,11 +234,6 @@ def matrix_inverse_root(
         NotImplementedError: If the root inverse config is not implemented.
 
     """
-
-    # check if matrix is scalar
-    if torch.numel(A) == 1:
-        return (A + epsilon).pow_(-1.0 / root)
-
     # check matrix shape
     if len(A.shape) != 2:
         raise ValueError("Matrix is not 2-dimensional!")
@@ -351,10 +346,6 @@ def matrix_eigendecomposition(
         NotImplementedError: If the eigendecomposition config is not implemented.
 
     """
-    # check if matrix is scalar
-    if torch.numel(A) == 1:
-        return A.squeeze(), torch.ones_like(A)
-
     # check matrix shape
     if len(A.shape) != 2:
         raise ValueError("Matrix is not 2-dimensional!")

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -157,27 +157,6 @@ class ScaleAndPowEigenvaluesTest(unittest.TestCase):
 
 @instantiate_parametrized_tests
 class MatrixInverseRootTest(unittest.TestCase):
-    def test_matrix_inverse_root_scalar(self) -> None:
-        A = torch.tensor(2.0)
-        root = 2.0
-        exp = 1.82
-        with self.subTest("Test with scalar case."):
-            self.assertEqual(
-                A ** torch.tensor(-exp / root),
-                matrix_inverse_root(
-                    A,
-                    root=Fraction(root / exp),
-                ),
-            )
-        with self.subTest("Test with matrix case."):
-            self.assertEqual(
-                torch.tensor([[A ** torch.tensor(-exp / root)]]),
-                matrix_inverse_root(
-                    torch.tensor([[A]]),
-                    root=Fraction(root / exp),
-                ),
-            )
-
     def test_matrix_inverse_root_with_not_two_dim_matrix(self) -> None:
         A = torch.zeros((1, 2, 3))
         root = Fraction(4)
@@ -799,19 +778,6 @@ class ComputeMatrixRootInverseResidualsTest(unittest.TestCase):
 
 @instantiate_parametrized_tests
 class MatrixEigendecompositionTest(unittest.TestCase):
-    def test_matrix_eigendecomposition_scalar(self) -> None:
-        A = torch.tensor(2.0)
-        with self.subTest("Test with scalar case."):
-            self.assertEqual(
-                (A, torch.tensor(1)),
-                matrix_eigendecomposition(A),
-            )
-        with self.subTest("Test with matrix case."):
-            self.assertEqual(
-                (torch.tensor([[A]]), torch.tensor([[1]])),
-                matrix_eigendecomposition(torch.tensor([[A]])),
-            )
-
     def test_matrix_eigendecomposition_with_not_two_dim_matrix(self) -> None:
         A = torch.zeros((1, 2, 3))
         self.assertRaisesRegex(


### PR DESCRIPTION
Summary:
Done by gavinzhang.

This diff added a test case where epsilon is deliberately set to be very large (eps = 80). Manually computed the expected preconditioned gradients to compare with the outputs of shampoo preconditioner list. The goal of this unit test is to ensure the accuracy of the matrix inverse function for larger values of epsilon, so that in the future we might set an algorithmic epsilon that may be deliberately large.

This diff also fixes other bugs related with pseudo-inverse.

Differential Revision: D74108446


