### PR TITLE
Simplify `shampoo_distributor_test.py`

### DIFF
--- a/distributed_shampoo/utils/tests/shampoo_distributor_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_distributor_test.py
@@ -16,76 +16,71 @@ import torch
 from distributed_shampoo.distributed_shampoo import DistributedShampoo
 from distributed_shampoo.tests.shampoo_test_utils import construct_training_problem
 from distributed_shampoo.utils.shampoo_block_info import BlockInfo
-from distributed_shampoo.utils.shampoo_distributor import (
-    Distributor,
-    DistributorInterface,
-)
+from distributed_shampoo.utils.shampoo_distributor import Distributor
 from torch import nn
 
+PRECONDITIONER_DIM = 5
 
-class DistributorInterfaceTest(unittest.TestCase):
-    """DistributorInterfaceTest is the base class for testing all the single process Distributor implementation.
 
-    Note that all the subclasses may not implement setUp() and only need to implement _get_distributor_type()
-    to enable the the usage of self._distributor.
-    """
-
+class DistributorTest(unittest.TestCase):
     def setUp(self) -> None:
-        self._model, _, _, _ = construct_training_problem(
-            (10, 5), model_dead_layers_dims=None, bias=True, fill=0.0
-        )
+        self._model = construct_training_problem(
+            (2 * PRECONDITIONER_DIM, PRECONDITIONER_DIM),
+            model_dead_layers_dims=None,
+            bias=True,
+            fill=0.0,
+        )[0]
         assert isinstance(self._model, nn.Module)
-        self._param_group = DistributedShampoo(
-            self._model.parameters(),
-            lr=0.01,
-            betas=(0.9, 1.0),
-            epsilon=1e-12,
-            momentum=0.0,
-            weight_decay=0.0,
-            max_preconditioner_dim=5,
-            precondition_frequency=1,
-            start_preconditioning_step=-1,
-        ).param_groups[0]
-        self._distributor = self._get_distributor_type()(param_group=self._param_group)
-
-    def _get_distributor_type(self) -> type[DistributorInterface]:
-        # Disable the abstract methods check from the interface so it is possible to instantiate DistributorInterface.
-        DistributorInterface.__abstractmethods__ = frozenset()
-        return DistributorInterface
-
-    def test_update_params(self) -> None:
-        self.assertIsNone(
-            self._distributor.update_params(masked_blocked_search_directions=())
+        self._distributor = Distributor(
+            param_group=DistributedShampoo(
+                self._model.parameters(),
+                lr=0.01,
+                betas=(0.9, 1.0),
+                epsilon=1e-12,
+                momentum=0.0,
+                weight_decay=0.0,
+                max_preconditioner_dim=PRECONDITIONER_DIM,
+                precondition_frequency=1,
+                start_preconditioning_step=-1,
+            ).param_groups[0]
         )
-
-    def test_merge_and_block_gradients(self) -> None:
-        self.assertIsNone(self._distributor.merge_and_block_gradients())
-
-
-class DistributorTest(DistributorInterfaceTest):
-    def _get_distributor_type(self) -> type[DistributorInterface]:
-        return Distributor
 
     def test_update_params(self) -> None:
         # Explicitly disable the gradient of the bias layer and call merge_and_block_gradients()
         # to update the local gradient selector.
-        self._model.linear_layers[0].weight.grad = torch.ones((5, 10))  # type: ignore[index, union-attr]
+        self._model.linear_layers[0].weight.grad = torch.ones_like(  # type: ignore[index, union-attr]
+            (
+                self._model.linear_layers[0].weight  # type: ignore[index, union-attr]
+            )
+        )
         self._model.linear_layers[0].bias.grad = None  # type: ignore[index, union-attr]
         self._distributor.merge_and_block_gradients()
 
         actual_masked_blocked_params = self._distributor.local_masked_blocked_params
 
         masked_blocked_search_directions = (
-            torch.arange(5 * 5, dtype=torch.float).reshape(5, 5),
-            torch.arange(5 * 5, 2 * 5 * 5, dtype=torch.float).reshape(5, 5),
+            torch.arange(
+                PRECONDITIONER_DIM * PRECONDITIONER_DIM, dtype=torch.float
+            ).reshape(PRECONDITIONER_DIM, PRECONDITIONER_DIM),
+            torch.arange(
+                PRECONDITIONER_DIM * PRECONDITIONER_DIM,
+                2 * PRECONDITIONER_DIM * PRECONDITIONER_DIM,
+                dtype=torch.float,
+            ).reshape(PRECONDITIONER_DIM, PRECONDITIONER_DIM),
         )
         self._distributor.update_params(
-            masked_blocked_search_directions,
+            masked_blocked_search_directions=masked_blocked_search_directions
         )
 
         expected_masked_blocked_params = (
-            torch.arange(5 * 5, dtype=torch.float).reshape(5, 5),
-            torch.arange(5 * 5, 2 * 5 * 5, dtype=torch.float).reshape(5, 5),
+            torch.arange(
+                PRECONDITIONER_DIM * PRECONDITIONER_DIM, dtype=torch.float
+            ).reshape(PRECONDITIONER_DIM, PRECONDITIONER_DIM),
+            torch.arange(
+                PRECONDITIONER_DIM * PRECONDITIONER_DIM,
+                2 * PRECONDITIONER_DIM * PRECONDITIONER_DIM,
+                dtype=torch.float,
+            ).reshape(PRECONDITIONER_DIM, PRECONDITIONER_DIM),
         )
         torch.testing.assert_close(
             actual_masked_blocked_params, expected_masked_blocked_params
@@ -94,7 +89,9 @@ class DistributorTest(DistributorInterfaceTest):
     def test_local_grad_selector(self) -> None:
         # Explicitly disable the gradient of the bias layer and call merge_and_block_gradients()
         # to update the local gradient selector for the bias layer (i.e., 3rd block).
-        self._model.linear_layers[0].weight.grad = torch.ones((5, 10))  # type: ignore[index, union-attr]
+        self._model.linear_layers[0].weight.grad = torch.ones_like(  # type: ignore[index, union-attr]
+            self._model.linear_layers[0].weight  # type: ignore[index, union-attr]
+        )
         self._model.linear_layers[0].bias.grad = None  # type: ignore[index, union-attr]
         self._distributor.merge_and_block_gradients()
 
@@ -108,9 +105,9 @@ class DistributorTest(DistributorInterfaceTest):
         # In Distributor, because there is no global vs. local boundary concept,
         # global and local blocked params are always identical.
         expected_local_params = (
-            torch.zeros(5, 5, dtype=torch.float),
-            torch.zeros(5, 5, dtype=torch.float),
-            torch.zeros(5, dtype=torch.float),
+            torch.zeros(PRECONDITIONER_DIM, PRECONDITIONER_DIM, dtype=torch.float),
+            torch.zeros(PRECONDITIONER_DIM, PRECONDITIONER_DIM, dtype=torch.float),
+            torch.zeros(PRECONDITIONER_DIM, dtype=torch.float),
         )
         torch.testing.assert_close(
             self._distributor.local_blocked_params,
@@ -156,12 +153,14 @@ class DistributorTest(DistributorInterfaceTest):
             )
 
     def test_merge_and_block_gradients(self) -> None:
-        self._model.linear_layers[0].weight.grad = torch.ones((5, 10))  # type: ignore[index, union-attr]
+        self._model.linear_layers[0].weight.grad = torch.ones_like(  # type: ignore[index, union-attr]
+            self._model.linear_layers[0].weight  # type: ignore[index, union-attr]
+        )
         self._model.linear_layers[0].bias.grad = None  # type: ignore[index, union-attr]
         actual_local_masked_block_grads = self._distributor.merge_and_block_gradients()
         expected_local_masked_block_grads = (
-            torch.ones((5, 5)),
-            torch.ones((5, 5)),
+            torch.ones((PRECONDITIONER_DIM, PRECONDITIONER_DIM)),
+            torch.ones((PRECONDITIONER_DIM, PRECONDITIONER_DIM)),
         )
         torch.testing.assert_close(
             actual_local_masked_block_grads, expected_local_masked_block_grads


### PR DESCRIPTION
Summary: Removing the `DistributorInterface` test case becase its corresponding interfaces could be tested with existing `DistributorTest` test case.

Differential Revision: D74221982


