### PR TITLE
Fix mypy complains on `optimizer_modules.py`

### DIFF
--- a/optimizer_modules.py
+++ b/optimizer_modules.py
@@ -100,7 +100,8 @@ class OptimizerModule:
                 elif isinstance(value, (list, tuple, set)):
                     destination[key] = {}
                     save_to_state_dict(
-                        states=enumerate(value),
+                        # Note: mypy is right on this typing error but it is impossible to flatten one more level of codes to eliminate this.
+                        states=enumerate(value),  # type: ignore[arg-type]
                         destination=destination[key],
                     )
                 elif store_non_tensors:


### PR DESCRIPTION
Summary:
The [current mypy reports](https://github.com/facebookresearch/optimizers/actions/runs/14890602922/job/41821453053) incompatible types on `states` argument of `save_to_state_dict()` after https://github.com/facebookresearch/optimizers/commit/4beb33f3e8ebb8706ebf1e60c31fcce93025ccbb.

Even though mypy is right on this incorrect typing because `enumerate()` returns `Iterable[int, Any]` but this will collide with the type hints of `destination`, which is `StateDict`, requires key as a string.

The only solution is to do one level flattening of current parsing to relax the constraintt of `destination` into `dict[Hashable, Any]`; however, this is too much works and `typing.Any` is not allowed in the current setting.

As a result, ignore this typing complain from mypy.

Differential Revision: D74356894


