### PR TITLE
Improve the type hints of `_get_params_or_grads()`

### DIFF
--- a/distributed_shampoo/utils/shampoo_distributor.py
+++ b/distributed_shampoo/utils/shampoo_distributor.py
@@ -111,17 +111,15 @@ class DistributorInterface(ABC):
 
     @overload
     @torch.no_grad()
-    def _get_params_or_grads(self) -> Iterable[Tensor]: ...
-
-    @overload
-    @torch.no_grad()
     def _get_params_or_grads(
         self, get_grad: Literal[True]
     ) -> Iterable[Tensor | None]: ...
 
     @overload
     @torch.no_grad()
-    def _get_params_or_grads(self, get_grad: Literal[False]) -> Iterable[Tensor]: ...
+    def _get_params_or_grads(
+        self, get_grad: Literal[False] = False
+    ) -> Iterable[Tensor]: ...
 
     @torch.no_grad()
     def _get_params_or_grads(self, get_grad: bool = False) -> Iterable[Tensor | None]:

--- a/distributed_shampoo/utils/shampoo_fully_shard_distributor.py
+++ b/distributed_shampoo/utils/shampoo_fully_shard_distributor.py
@@ -31,17 +31,15 @@ class FullyShardDistributor(Distributor):
 
     @overload
     @torch.no_grad()
-    def _get_params_or_grads(self) -> Iterable[Tensor]: ...
-
-    @overload
-    @torch.no_grad()
     def _get_params_or_grads(
         self, get_grad: Literal[True]
     ) -> Iterable[Tensor | None]: ...
 
     @overload
     @torch.no_grad()
-    def _get_params_or_grads(self, get_grad: Literal[False]) -> Iterable[Tensor]: ...
+    def _get_params_or_grads(
+        self, get_grad: Literal[False] = False
+    ) -> Iterable[Tensor]: ...
 
     @torch.no_grad()
     def _get_params_or_grads(self, get_grad: bool = False) -> Iterable[Tensor | None]:

--- a/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
@@ -221,17 +221,15 @@ class HybridShardDistributor(DistributorInterface):
 
     @overload
     @torch.no_grad()
-    def _get_params_or_grads(self) -> Iterable[Tensor]: ...
-
-    @overload
-    @torch.no_grad()
     def _get_params_or_grads(
         self, get_grad: Literal[True]
     ) -> Iterable[Tensor | None]: ...
 
     @overload
     @torch.no_grad()
-    def _get_params_or_grads(self, get_grad: Literal[False]) -> Iterable[Tensor]: ...
+    def _get_params_or_grads(
+        self, get_grad: Literal[False] = False
+    ) -> Iterable[Tensor]: ...
 
     @torch.no_grad()
     def _get_params_or_grads(self, get_grad: bool = False) -> Iterable[Tensor | None]:


### PR DESCRIPTION
Summary: Figure out how to type hint when there is a default value of `get_grad=False` in `_get_params_or_grads()`.

Differential Revision: D74560386


