### PR TITLE
Open-sourced update on 05/19/2025

### DIFF
--- a/commons.py
+++ b/commons.py
@@ -57,12 +57,12 @@ class AbstractDataclass(ABC):
         """An abstract method that must be implemented by all subclasses."""
 
 
-SubclassesType = TypeVar("SubclassesType")
+_SubclassesType = TypeVar("_SubclassesType")
 
 
 def get_all_subclasses(
-    cls: SubclassesType, include_cls_self: bool = True
-) -> list[SubclassesType]:
+    cls: _SubclassesType, include_cls_self: bool = True
+) -> list[_SubclassesType]:
     """
     Retrieves all subclasses of a given class, optionally including the class itself.
 
@@ -77,7 +77,7 @@ def get_all_subclasses(
         list[SubclassesType]: A list of all unique subclasses of the given class.
     """
 
-    def get_all_unique_subclasses(cls: SubclassesType) -> set[SubclassesType]:
+    def get_all_unique_subclasses(cls: _SubclassesType) -> set[_SubclassesType]:
         """Gets all unique subclasses of a given class recursively."""
         return reduce(
             or_,

--- a/distributed_shampoo/README.md
+++ b/distributed_shampoo/README.md
@@ -288,7 +288,6 @@ import torch.distributed as dist
 
 from distributed_shampoo import (
     AdamGraftingConfig,
-    CommunicationDType,
     DDPShampooConfig,
     DistributedShampoo,
 )
@@ -326,7 +325,7 @@ optimizer = DistributedShampoo(
         epsilon=1e-12,
     ),
     distributed_config=DDPShampooConfig(
-        communication_dtype=CommunicationDType.FP32,
+        communication_dtype=torch.float32,
         num_trainers_per_group=8,
         communicate_params=False,
     ),
@@ -680,7 +679,7 @@ With the inclusion of learning rate grafting, we can extract a good learning rat
 5. If enabling DDP Shampoo, you can tune for performance:
 
     * **Process Group Size** (`num_trainers_per_group`): For large-scale distributed jobs, this hyperparameter allows us to trade off computational and communication costs. Assuming the number of GPUs per node is 8, one should search for a value in $\{8,16,32,64\}$. This hyperparameter has no impact on model quality.
-    * **Quantized Communications** (`communication_dtype`): One can enable quantized communications by setting the `communication_dtype`. We have found that using `CommunicationDType.FP16` works well in practice (with `communicate_params = False`).
+    * **Quantized Communications** (`communication_dtype`): One can enable quantized communications by setting the `communication_dtype`. We have found that using `torch.float16` works well in practice (with `communicate_params = False`).
     * **Communicate Updated Parameters** (`communicate_params`): If one does not enable quantized communications, one can possibly obtain better performance by communicating the updated parameters by setting this to `True`.
 
 ## Commmon Questions

--- a/distributed_shampoo/__init__.py
+++ b/distributed_shampoo/__init__.py
@@ -11,7 +11,6 @@ from distributed_shampoo.distributed_shampoo import DistributedShampoo
 from distributed_shampoo.shampoo_types import (
     AdaGradGraftingConfig,
     AdamGraftingConfig,
-    CommunicationDType,
     DDPShampooConfig,
     DefaultEigenvalueCorrectedShampooConfig,
     DefaultShampooConfig,
@@ -82,5 +81,4 @@ __all__ = [
     "CoupledHigherOrderConfig",  # Based on `RootInvConfig`.
     # Other utilities.
     "compile_fsdp_parameter_metadata",  # For `FSDPShampooConfig` and `HSDPShampooConfig`.
-    "CommunicationDType",  # For `DDPShampooConfig` and `HSDPShampooConfig`.
 ]

--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -992,9 +992,7 @@ class DistributedShampooNoneGradTest(unittest.TestCase):
             max_preconditioner_dim=5,
             precondition_frequency=1,
             start_preconditioning_step=1,
-            shampoo_pt2_compile_config=ShampooPT2CompileConfig(
-                pytorch_compile_backend="eager"
-            ),
+            shampoo_pt2_compile_config=ShampooPT2CompileConfig(backend="eager"),
             distributed_config=None,
             # Explicity set grafting_config=None to test the case that no grafting is used.
             grafting_config=None,

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -135,8 +135,8 @@ class SGDPreconditionerList(PreconditionerList):
         return
 
 
-SubStateValueType = TypeVar("SubStateValueType")
-StateValueType = dict[Hashable, SubStateValueType]
+_SubStateValueType = TypeVar("_SubStateValueType")
+_StateValueType = dict[Hashable, _SubStateValueType]
 
 
 class AdagradPreconditionerList(PreconditionerList):
@@ -154,7 +154,7 @@ class AdagradPreconditionerList(PreconditionerList):
 
     Args:
         block_list (tuple[Tensor, ...]): List of (blocks of) parameters.
-        state (Mapping[Tensor, Any]): Mapping containing optimizer state.
+        state (Mapping[Tensor, _StateValueType]): Mapping containing optimizer state.
         block_info_list (tuple[BlockInfo, ...]): List containing corresponding BlockInfo for each block/parameter in block_list.
             Note that this should have the same length as block_list.
         beta2 (float): Exponential moving average factor for Adam/RMSprop second moment state. If beta2 = 1., will use
@@ -167,7 +167,7 @@ class AdagradPreconditionerList(PreconditionerList):
     def __init__(
         self,
         block_list: tuple[Tensor, ...],
-        state: Mapping[Tensor, StateValueType],
+        state: Mapping[Tensor, _StateValueType],
         block_info_list: tuple[BlockInfo, ...],
         beta2: float = 1.0,
         epsilon: float = 1e-10,
@@ -710,14 +710,14 @@ class EigenvalueCorrectedShampooKroneckerFactorsUnwrapped(
         assert len(self.factor_matrices) == len(self.factor_matrices_eigenvectors)
 
 
-ShampooKroneckerFactorsStateType = TypeVar(
-    "ShampooKroneckerFactorsStateType",
+_ShampooKroneckerFactorsStateType = TypeVar(
+    "_ShampooKroneckerFactorsStateType",
     RootInvShampooKroneckerFactorsState,
     EigendecomposedShampooKroneckerFactorsState,
     EigenvalueCorrectedShampooKroneckerFactorsState,
 )
-ShampooKroneckerFactorsUnwrappedType = TypeVar(
-    "ShampooKroneckerFactorsUnwrappedType",
+_ShampooKroneckerFactorsUnwrappedType = TypeVar(
+    "_ShampooKroneckerFactorsUnwrappedType",
     RootInvShampooKroneckerFactorsUnwrapped,
     EigendecomposedShampooKroneckerFactorsUnwrapped,
     EigenvalueCorrectedShampooKroneckerFactorsUnwrapped,
@@ -726,7 +726,7 @@ ShampooKroneckerFactorsUnwrappedType = TypeVar(
 
 class BaseShampooPreconditionerList(
     PreconditionerList,
-    Generic[ShampooKroneckerFactorsStateType, ShampooKroneckerFactorsUnwrappedType],
+    Generic[_ShampooKroneckerFactorsStateType, _ShampooKroneckerFactorsUnwrappedType],
 ):
     """Base class for Shampoo preconditioners.
 
@@ -734,7 +734,7 @@ class BaseShampooPreconditionerList(
 
     Args:
         block_list (tuple[Tensor, ...]): List of (blocks of) parameters.
-        state (Mapping[Tensor, Any]): Mapping containing optimizer state.
+        state (Mapping[Tensor, _StateValueType]): Mapping containing optimizer state.
         block_info_list (tuple[BlockInfo, ...]): List containing corresponding BlockInfo for each block/parameter in block_list.
             Note that this should have the same length as block_list.
         preconditioner_config (PreconditionerConfig): Configuration for preconditioner computation.
@@ -749,7 +749,7 @@ class BaseShampooPreconditionerList(
     def __init__(
         self,
         block_list: tuple[Tensor, ...],
-        state: Mapping[Tensor, StateValueType],
+        state: Mapping[Tensor, _StateValueType],
         block_info_list: tuple[BlockInfo, ...],
         preconditioner_config: PreconditionerConfig,
         beta2: float = 1.0,
@@ -780,7 +780,7 @@ class BaseShampooPreconditionerList(
         )
 
         # Create the Kronecker factors.
-        kronecker_factors_unwrapped: list[ShampooKroneckerFactorsUnwrappedType] = (
+        kronecker_factors_unwrapped: list[_ShampooKroneckerFactorsUnwrappedType] = (
             self._create_kronecker_factors_state(
                 block_list=block_list,
                 state=state,
@@ -815,10 +815,10 @@ class BaseShampooPreconditionerList(
     def _create_kronecker_factors_state(
         self,
         block_list: tuple[Tensor, ...],
-        state: Mapping[Tensor, StateValueType],
+        state: Mapping[Tensor, _StateValueType],
         block_info_list: tuple[BlockInfo, ...],
         preconditioned_dims_list: tuple[tuple[int, ...], ...],
-    ) -> list[ShampooKroneckerFactorsUnwrappedType]:
+    ) -> list[_ShampooKroneckerFactorsUnwrappedType]:
         # Instantiate (blocked) Kronecker factors and construct list of Kronecker factors.
         # NOTE: We need to instantiate the Kronecker factor states within the optimizer's state dictionary,
         # and do not explicitly store them as RootInvShampooPreconditionerList attributes here.
@@ -977,13 +977,13 @@ class BaseShampooPreconditionerList(
     def _initialize_state_lists(
         self,
         block_list: tuple[Tensor, ...],
-        kronecker_factors_unwrapped: list[ShampooKroneckerFactorsUnwrappedType],
+        kronecker_factors_unwrapped: list[_ShampooKroneckerFactorsUnwrappedType],
         preconditioned_dims_list: tuple[tuple[int, ...], ...],
         preconditioned_dims_selector_list: tuple[tuple[bool, ...], ...],
     ) -> None:
         # Initialize local lists.
         self._local_kronecker_factors_unwrapped: tuple[
-            ShampooKroneckerFactorsUnwrappedType,
+            _ShampooKroneckerFactorsUnwrappedType,
             ...,
         ] = tuple(kronecker_factors_unwrapped)
         self._local_order_list: tuple[int, ...] = tuple(
@@ -1008,7 +1008,7 @@ class BaseShampooPreconditionerList(
             self._local_failed_amortized_computation_counter_list
         )
         self._masked_kronecker_factors_unwrapped: tuple[
-            ShampooKroneckerFactorsUnwrappedType,
+            _ShampooKroneckerFactorsUnwrappedType,
             ...,
         ] = self._local_kronecker_factors_unwrapped
         self._masked_preconditioned_dims_selector_list: tuple[tuple[bool, ...], ...] = (
@@ -1049,7 +1049,7 @@ class BaseShampooPreconditionerList(
                 )
             )
             self._masked_kronecker_factors_unwrapped: tuple[  # type: ignore[no-redef]
-                ShampooKroneckerFactorsUnwrappedType,
+                _ShampooKroneckerFactorsUnwrappedType,
                 ...,
             ] = compress_list(
                 self._local_kronecker_factors_unwrapped, local_grad_selector
@@ -1128,14 +1128,14 @@ class BaseShampooPreconditionerList(
         )
 
 
-ClassicShampooKroneckerFactorsStateType = TypeVar(
-    "ClassicShampooKroneckerFactorsStateType",
+_ClassicShampooKroneckerFactorsStateType = TypeVar(
+    "_ClassicShampooKroneckerFactorsStateType",
     RootInvShampooKroneckerFactorsState,
     EigendecomposedShampooKroneckerFactorsState,
 )
 
-ClassicShampooKroneckerFactorsUnwrappedType = TypeVar(
-    "ClassicShampooKroneckerFactorsUnwrappedType",
+_ClassicShampooKroneckerFactorsUnwrappedType = TypeVar(
+    "_ClassicShampooKroneckerFactorsUnwrappedType",
     RootInvShampooKroneckerFactorsUnwrapped,
     EigendecomposedShampooKroneckerFactorsUnwrapped,
 )
@@ -1143,8 +1143,8 @@ ClassicShampooKroneckerFactorsUnwrappedType = TypeVar(
 
 class ClassicShampooPreconditionerList(
     BaseShampooPreconditionerList[
-        ClassicShampooKroneckerFactorsStateType,
-        ClassicShampooKroneckerFactorsUnwrappedType,
+        _ClassicShampooKroneckerFactorsStateType,
+        _ClassicShampooKroneckerFactorsUnwrappedType,
     ]
 ):
     """Base class for Shampoo preconditioners that rely on ShampooPreconditionerConfig.

--- a/distributed_shampoo/utils/shampoo_utils.py
+++ b/distributed_shampoo/utils/shampoo_utils.py
@@ -30,8 +30,6 @@ def merge_small_dims(tensor_shape: Sequence[int], threshold: int) -> tuple[int, 
         new_tensor_shape (tuple[int, ...]): New tensor shape.
 
     """
-    if not tensor_shape:
-        return ()
 
     # Squeeze tensor shape to remove dimension with 1; if all dimensions are 1,
     # then add a 1 to the tensor shape.
@@ -65,12 +63,12 @@ def multi_dim_split(tensor: Tensor, split_size: int) -> tuple[Tensor, ...]:
     )
 
 
-CompressListType = TypeVar("CompressListType")
+_CompressListType = TypeVar("_CompressListType")
 
 
 def compress_list(
-    complete_list: Sequence[CompressListType], selector: Sequence[bool]
-) -> tuple[CompressListType, ...]:
+    complete_list: Sequence[_CompressListType], selector: Sequence[bool]
+) -> tuple[_CompressListType, ...]:
     """Compresses sequence based on selector.
 
     NOTE: Despite the name, this function can compress both lists and tuples, but will always return
@@ -130,7 +128,7 @@ def generate_pairwise_indices(input_list: Sequence[int]) -> Iterator[tuple[int, 
     return pairwise(accumulate(chain([0], input_list)))
 
 
-ParameterizeEnterExitContextType = TypeVar("ParameterizeEnterExitContextType")
+_ParameterizeEnterExitContextType = TypeVar("_ParameterizeEnterExitContextType")
 
 
 class ParameterizeEnterExitContext:
@@ -145,9 +143,9 @@ class ParameterizeEnterExitContext:
 
     def __init__(
         self,
-        input_with_enter_exit_context: ParameterizeEnterExitContextType,
-        enter_method_caller: Callable[[ParameterizeEnterExitContextType], None],
-        exit_method_caller: Callable[[ParameterizeEnterExitContextType], None],
+        input_with_enter_exit_context: _ParameterizeEnterExitContextType,
+        enter_method_caller: Callable[[_ParameterizeEnterExitContextType], None],
+        exit_method_caller: Callable[[_ParameterizeEnterExitContextType], None],
     ) -> None:
         self._enter_method: Callable[[], None] = partial(
             enter_method_caller, input_with_enter_exit_context

--- a/distributed_shampoo/utils/tests/shampoo_utils_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_utils_test.py
@@ -65,7 +65,7 @@ class MergeSmallDimsTest(unittest.TestCase):
 
     @parametrize("threshold", (10, 1))
     def test_empty_dims(self, threshold: int) -> None:
-        expected_new_tensor_shape = ()
+        expected_new_tensor_shape = (1,)
         self.assertEqual(
             merge_small_dims(tensor_shape=(), threshold=threshold),
             expected_new_tensor_shape,

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -55,12 +55,12 @@ class NewtonConvergenceFlag(enum.Enum):
     EARLY_STOP = enum.auto()
 
 
-FuncReturnType = TypeVar("FuncReturnType")
-DataclassType = TypeVar("DataclassType")
+_FuncReturnType = TypeVar("_FuncReturnType")
+_DataclassType = TypeVar("_DataclassType")
 
 
 def _get_function_args_from_config(
-    func: Callable[..., FuncReturnType], config: DataclassType
+    func: Callable[..., _FuncReturnType], config: _DataclassType
 ) -> dict[str, Any]:
     """
     Returns a dict of arguments for func that are defined in config. Note that config is not expected to contain all arguments for func, nor are all fields in config expected to be applicable to func.
@@ -73,8 +73,8 @@ def _get_function_args_from_config(
 
 
 def _check_square_matrix(
-    func: Callable[..., FuncReturnType],
-) -> Callable[..., FuncReturnType]:
+    func: Callable[..., _FuncReturnType],
+) -> Callable[..., _FuncReturnType]:
     """
     Decorator to check if the input matrix is square.
 
@@ -90,7 +90,7 @@ def _check_square_matrix(
     """
 
     @wraps(func)
-    def wrapper(A: Tensor, *args: Any, **kwargs: Any) -> FuncReturnType:
+    def wrapper(A: Tensor, *args: Any, **kwargs: Any) -> _FuncReturnType:
         if len(A.shape) != 2:
             raise ValueError(f"Matrix is not 2-dimensional! {A.shape=}")
         if A.shape[0] != A.shape[1]:

--- a/optimizer_modules.py
+++ b/optimizer_modules.py
@@ -17,7 +17,7 @@ from torch.optim.optimizer import StateDict
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-StateType = TypeVar("StateType")
+_StateType = TypeVar("_StateType")
 
 
 class OptimizerModule:
@@ -65,7 +65,7 @@ class OptimizerModule:
         """
 
         def save_to_state_dict(
-            states: Iterable[tuple[str, StateType]], destination: StateDict
+            states: Iterable[tuple[str, _StateType]], destination: StateDict
         ) -> None:
             r"""Saves module state to `destination` dictionary, containing a state
             of the module, but not its descendants. This is called on every


### PR DESCRIPTION
Summary:
1. Remove `CommunicationDType` enum in favor of native `torch.dtype`.
2. Adjust the parsing of `preconditioner-dtype` by using `torch.dtype` directly.
3. Renaming `TypeVar` variables to reflect its private meaning.
4. Add test for comparing HSDP2 Shampoo in n replicate one shard setting against regular Shampoo done by @wz337 .
5. Extend the support of PyTorch 2 compile by providing more options in `ShampooPT2CompileConfig`.

Differential Revision: D74921339


