### PR TITLE
Fix typing complain in `commons_test.py`

### DIFF
--- a/tests/commons_test.py
+++ b/tests/commons_test.py
@@ -74,7 +74,7 @@ class BatchedTest(unittest.TestCase):
 
     def test_empty_iterable(self) -> None:
         """Test batching an empty iterable."""
-        data = []
+        data: list[int] = []
         result = list(batched(data, n=3))
         self.assertEqual(result, [])
 


### PR DESCRIPTION
Summary: Basd on https://github.com/facebookresearch/optimizers/actions/runs/15281936361/job/42982859265, this empty list needs be typed to prevent mypy error.

Differential Revision: D75540479


