### PR TITLE
Remove redundant keyword argument and fix typing complain

### DIFF
--- a/distributed_shampoo/shampoo_types.py
+++ b/distributed_shampoo/shampoo_types.py
@@ -21,7 +21,6 @@ from matrix_functions_types import (
     EigendecompositionConfig,
     MatrixFunctionConfig,
     QREigendecompositionConfig,
-    RootInvConfig,
 )
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import ShardingStrategy
@@ -97,7 +96,7 @@ class ShampooPreconditionerConfig(PreconditionerConfig):
     """Configuration for Shampoo preconditioner computation.
 
     Attributes:
-        amortized_computation_config (RootInvConfig | EigendecompositionConfig): Configuration for the inverse-root computation. (Default: DefaultEigenConfig)
+        amortized_computation_config (MatrixFunctionConfig): Configuration for the inverse-root computation. (Default: DefaultEigenConfig)
         num_tolerated_failed_amortized_computations (int): Number of failed amortized computations to tolerate before raising an error. (Default: 3)
         inverse_exponent_override (dict[int, dict[int, float] | float]): The inverse_exponent_override attribute is a dictionary that allows for customizing the inverse exponent used in the Shampoo preconditioner computation.
             The keys of the dictionary represent the order of the tensor, and the values are either dictionaries with dimension indices as keys and override values as values, or a single float value for all dimensions. All unspecified dimensions use a default exponent of 1/(2*max(o,1)), where o is the order of the tensor. (Default: {})
@@ -138,7 +137,7 @@ class ShampooPreconditionerConfig(PreconditionerConfig):
 
     """
 
-    amortized_computation_config: RootInvConfig | EigendecompositionConfig = field(
+    amortized_computation_config: MatrixFunctionConfig = field(
         default_factory=lambda: DefaultEigenConfig
     )
     inverse_exponent_override: dict[int, dict[int, float] | float] = field(

--- a/distributed_shampoo/utils/shampoo_preconditioner_list.py
+++ b/distributed_shampoo/utils/shampoo_preconditioner_list.py
@@ -1639,6 +1639,7 @@ class EigenvalueCorrectedShampooPreconditionerList(
                 preconditioned_dims_selector=preconditioned_dims_selector,
                 preconditioner_list=kronecker_factors.factor_matrices_eigenvectors,
             )
+
             # Verify that the number of roots is 1 in Eigenvalue-Corrected Shampoo preconditioner.
             assert len(roots) == 1, f"{len(roots)=} != 1"
             # TODO: remove assertion when rank_deficient_stability_config is generalized to MatrixFunctionConfig

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -353,23 +353,19 @@ class BaseShampooPreconditionerListTest(unittest.TestCase):
         # Disable the abstract methods check from the interface so it is possible to instantiate BaseShampooPreconditionerList.
         BaseShampooPreconditionerList.__abstractmethods__ = frozenset()
 
-        with (
-            mock.patch.object(
-                # Mock compress_list() to enable the instantiation of BaseShampooPreconditionerList.
-                shampoo_preconditioner_list,
-                "compress_list",
-                return_value=(True,) * max(param.dim(), 1),
-            ) as mock_compress_list,
-            mock.patch.object(
-                BaseShampooPreconditionerList,
-                "_create_kronecker_factors_state",
-            ) as mock_create_kronecker_factor_state,
-            mock.patch.object(
-                # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
-                BaseShampooPreconditionerList,
-                "_update_factor_matrices",
-            ) as mock_update_factor_matrices,
-        ):
+        with mock.patch.object(
+            # Mock compress_list() to enable the instantiation of BaseShampooPreconditionerList.
+            shampoo_preconditioner_list,
+            "compress_list",
+            return_value=(True,) * max(param.dim(), 1),
+        ) as mock_compress_list, mock.patch.object(
+            BaseShampooPreconditionerList,
+            "_create_kronecker_factors_state",
+        ) as mock_create_kronecker_factor_state, mock.patch.object(
+            # Mock _update_factor_matrices() otherwise the access of factor_matrices will throw errors.
+            BaseShampooPreconditionerList,
+            "_update_factor_matrices",
+        ) as mock_update_factor_matrices:
             # Test the abstract methods _create_preconditioned_dims_selector() and _get_inverse_roots_from_override().
             preconditioner_list = methodcaller(
                 "__call__",
@@ -614,15 +610,12 @@ class AbstractTest:
                 )
 
         def test_amortized_computation_internal_failure(self) -> None:
-            with (
-                mock.patch.object(
-                    shampoo_preconditioner_list,
-                    self._amortized_computation_properties.amortized_computation_function_name,
-                    # Simulate the situation throws an exception (not nan and inf) to test the warning
-                    side_effect=ZeroDivisionError,
-                ) as mock_amortized_computation,
-                self.assertLogs(level="WARNING") as cm,
-            ):
+            with mock.patch.object(
+                shampoo_preconditioner_list,
+                self._amortized_computation_properties.amortized_computation_function_name,
+                # Simulate the situation throws an exception (not nan and inf) to test the warning
+                side_effect=ZeroDivisionError,
+            ) as mock_amortized_computation, self.assertLogs(level="WARNING") as cm:
                 self._preconditioner_list.update_preconditioners(
                     masked_grad_list=(
                         torch.tensor([1.0, 0.0]),

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -247,14 +247,11 @@ class AdagradPreconditionerListTest(AbstractPreconditionerListTest.Interface):
             self._params[2],
         )
 
-    def _instantiate_preconditioner_list(
-        self, epsilon: float = 0.0, **kwargs: Any
-    ) -> AdagradPreconditionerList:  # type: ignore[override]
+    def _instantiate_preconditioner_list(self, **kwargs: Any) -> PreconditionerList:
         return AdagradPreconditionerList(
             block_list=self._block_list,
             state=self._state,
             block_info_list=self._block_info_list,
-            epsilon=epsilon,
             **kwargs,
         )
 
@@ -507,7 +504,7 @@ class AbstractTest:
 
             super().setUp()
 
-        def _instantiate_preconditioner_list(self, **kwargs: Any) -> PreconditionerList:  # type: ignore[override]
+        def _instantiate_preconditioner_list(self, **kwargs: Any) -> PreconditionerList:
             return self._preconditioner_list_factory(
                 block_list=self._block_list,
                 state=self._state,

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -424,14 +424,14 @@ def matrix_eigendecomposition(
 def _eigh_eigenvalue_decomposition(
     A: Tensor,
     retry_double_precision: bool = True,
-    eigendecomposition_offload_device: torch.device | str = "",
+    eigendecomposition_offload_device: str = "",
 ) -> tuple[Tensor, Tensor]:
     """Compute the eigendecomposition of a symmetric matrix using torch.linalg.eigh.
 
     Args:
         A (Tensor): The input symmetric matrix.
         retry_double_precision (bool): Whether to retry the computation in double precision if it fails in the current precision. (Default: True)
-        eigendecomposition_offload_device (torch.device | str): Device to offload eigendecomposition computation. If value is empty string, do not perform offloading. (Default: "")
+        eigendecomposition_offload_device (str): Device to offload eigendecomposition computation. If value is empty string, do not perform offloading. (Default: "")
 
     Returns:
         eigenvalues (Tensor): The eigenvalues of the input matrix A.
@@ -501,6 +501,7 @@ def _qr_algorithm(
     """Approximately compute the eigendecomposition of a symmetric matrix by performing the QR algorithm.
 
     Given an initial estimate of the eigenvectors Q of matrix A, QR iterations are performed until the criterion based on the estimated eigenvalues is below or equal to the specified tolerance or until the maximum number of iterations is reached.
+
     Note that if the criterion based on the estimated eigenvalues is already below or equal to the tolerance given the initial eigenvectors_estimate, the QR iterations will be skipped.
 
     Args:
@@ -553,7 +554,7 @@ def _matrix_inverse_root_eigen(
     epsilon: float = 0.0,
     rank_deficient_stability_config: RankDeficientStabilityConfig = DefaultPerturbationConfig,
     retry_double_precision: bool = True,
-    eigendecomposition_offload_device: torch.device | str = "",
+    eigendecomposition_offload_device: str = "",
 ) -> tuple[Tensor, Tensor, Tensor]:
     """Compute matrix inverse root using eigendecomposition of symmetric positive (semi-)definite matrix.
 
@@ -568,7 +569,7 @@ def _matrix_inverse_root_eigen(
         rank_deficient_stability_config (RankDeficientStabilityConfig): Configuration for handling/stabilizing rank-deficient matrices. (Default: DefaultPerturbationConfig)
         retry_double_precision (bool): Flag for re-trying eigendecomposition with higher precision if lower precision fails due
             to CuSOLVER failure. (Default: True)
-        eigendecomposition_offload_device (torch.device | str): Device to offload eigendecomposition computation. If value is empty string, do not perform offloading. (Default: "")
+        eigendecomposition_offload_device (str): Device to offload eigendecomposition computation. If value is empty string, do not perform offloading. (Default: "")
 
     Returns:
         X (Tensor): (Inverse) root of matrix. Same dimensions as A.

--- a/matrix_functions_types.py
+++ b/matrix_functions_types.py
@@ -89,19 +89,12 @@ class EighEigendecompositionConfig(EigendecompositionConfig):
         rank_deficient_stability_config (RankDeficientStabilityConfig): Configuration for handling/stabilizing rank-deficient matrices. (Default: DefaultPerturbationConfig)
         retry_double_precision (bool): Whether to re-trying eigendecomposition with higher (double) precision if lower precision fails due
             to CuSOLVER failure. (Default: True)
-        eigendecomposition_offload_device (torch.device | str): Device to offload eigendecomposition to. If value is empty string, we don't perform offloading. (Default: "")
+        eigendecomposition_offload_device (str): Device to offload eigendecomposition to. If value is empty string, we don't perform offloading. (Default: "")
 
     """
 
     retry_double_precision: bool = True
-    eigendecomposition_offload_device: torch.device | str = ""
-
-    def __post_init__(self) -> None:
-        # Convert an non-empty string to a torch.device; this verifies that the string is a valid device string early.
-        if self.eigendecomposition_offload_device != "":
-            self.eigendecomposition_offload_device = torch.device(
-                self.eigendecomposition_offload_device
-            )
+    eigendecomposition_offload_device: str = ""
 
 
 DefaultEigendecompositionConfig = EighEigendecompositionConfig()
@@ -155,7 +148,7 @@ class EigenConfig(RootInvConfig, EighEigendecompositionConfig):
         rank_deficient_stability_config (RankDeficientStabilityConfig): Configuration for handling/stabilizing rank-deficient matrices. (Default: DefaultPerturbationConfig)
         retry_double_precision (bool): Whether to re-trying eigendecomposition with higher (double) precision if lower precision fails due
             to CuSOLVER failure. (Default: True)
-        eigendecomposition_offload_device (torch.device | str): Device to offload eigendecomposition to. If value is empty string, we don't perform offloading. (Default: "")
+        eigendecomposition_offload_device (str): Device to offload eigendecomposition to. If value is empty string, we don't perform offloading. (Default: "")
         exponent_multiplier (float): Number to be multiplied to the numerator of the inverse root, i.e., eta where the
             exponent is -eta / (2 * p). (Default: 1.0)
         rank_deficient_stability_config (RankDeficientStabilityConfig): Configuration for handling/stabilizing rank-deficient matrices. (Default: DefaultPerturbationConfig)

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -282,22 +282,19 @@ class MatrixInverseRootTest(unittest.TestCase):
     ) -> None:
         A = torch.tensor([[1.0, 0.0], [0.0, 4.0]])
         root = Fraction(4)
-        with (
-            mock.patch.object(
-                matrix_functions,
-                implementation,
-                return_value=(
-                    None,
-                    None,
-                    NewtonConvergenceFlag.REACHED_MAX_ITERS,
-                    None,
-                    None,
-                ),
+        with mock.patch.object(
+            matrix_functions,
+            implementation,
+            return_value=(
+                None,
+                None,
+                NewtonConvergenceFlag.REACHED_MAX_ITERS,
+                None,
+                None,
             ),
-            self.assertLogs(
-                level="WARNING",
-            ) as cm,
-        ):
+        ), self.assertLogs(
+            level="WARNING",
+        ) as cm:
             matrix_inverse_root(
                 A=A,
                 root=root,

--- a/tests/matrix_functions_types_test.py
+++ b/tests/matrix_functions_types_test.py
@@ -13,45 +13,11 @@ import unittest
 import torch
 
 from commons import get_all_subclasses
-from matrix_functions_types import (
-    EighEigendecompositionConfig,
-    QREigendecompositionConfig,
-)
+from matrix_functions_types import QREigendecompositionConfig
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
-
-
-@instantiate_parametrized_tests
-class EighEigendecompositionConfigSubclassesTest(unittest.TestCase):
-    subclasses_types: list[type[EighEigendecompositionConfig]] = get_all_subclasses(
-        EighEigendecompositionConfig
-    )
-
-    @parametrize(
-        "eigendecomposition_offload_device",
-        ("cpu", "cuda", torch.device("cpu"), torch.device("cuda")),
-    )
-    @parametrize("cls", subclasses_types)
-    def test_eigendecomposition_offload_device(
-        self,
-        cls: type[EighEigendecompositionConfig],
-        eigendecomposition_offload_device: torch.device | str,
-    ) -> None:
-        config = cls(
-            eigendecomposition_offload_device=eigendecomposition_offload_device
-        )
-
-        # Check that the eigendecomposition_offload_device is a torch.device.
-        self.assertTrue(
-            isinstance(config.eigendecomposition_offload_device, torch.device)
-        )
-        # Check that the eigendecomposition_offload_device is the same as the one passed in.
-        self.assertEqual(
-            str(config.eigendecomposition_offload_device),
-            str(eigendecomposition_offload_device),
-        )
 
 
 @instantiate_parametrized_tests


### PR DESCRIPTION
Summary: `epsilon` is not needed in `AdagradPreconditionerListTest` and this should fix the current mypy complain on the return type.

Differential Revision: D75612743


