### PR TITLE
Fix mypy `type[override]` complain in `shampoo_checkpoint_utils_test.py`

### DIFF
--- a/distributed_shampoo/utils/tests/shampoo_checkpoint_utils_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_checkpoint_utils_test.py
@@ -34,8 +34,12 @@ class DummyOptimizerModule(OptimizerModule):
         self._field: Tensor = field
         self._thl: list[Tensor] = thl
 
-    def __eq__(self, other: "DummyOptimizerModule") -> bool:  # type: ignore[override]
-        return bool((self._field == other._field).item()) and self._thl == other._thl
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, DummyOptimizerModule)
+            and bool((self._field == other._field).item())
+            and self._thl == other._thl
+        )
 
 
 class ExtractStateDictContentTest(unittest.TestCase):


### PR DESCRIPTION
Summary: Properly typed `other` as `object` and make sure the equality check in one statement for better test coverage.

Differential Revision: D75749398


