### PR TITLE
Properly type hint `construct_training_problem()` and `train_model()`

### DIFF
--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -36,7 +36,7 @@ from distributed_shampoo.tests.shampoo_test_utils import (
 )
 from matrix_functions_types import DefaultEigendecompositionConfig
 
-from torch import distributed as dist, nn, tensor
+from torch import distributed as dist, tensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate
@@ -191,7 +191,6 @@ class AbstractTest:
                 num_steps=num_steps,
             )
 
-            assert isinstance(model, nn.Module)
             assert isinstance(optimizer, DistributedShampoo)
             # Retrieve the distributed state dictionary of the first layer (i.e., the only layer) from the optimizer.
             distributed_state_dict = optimizer.distributed_state_dict(
@@ -413,7 +412,6 @@ class AbstractTest:
                 ),
                 num_steps=steps_with_gradients,
             )
-            assert isinstance(model, nn.Module)
 
             steps_without_gradients = 3
             for _ in range(steps_without_gradients):
@@ -457,7 +455,6 @@ class AbstractTest:
                 ),
                 num_steps=num_steps,
             )
-            assert isinstance(model, nn.Module)
 
             assert isinstance(optimizer, DistributedShampoo)
             # For each rank, no matter getting gradients or not, the step should be updated.

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
@@ -88,7 +88,6 @@ class ShampooFSDPDistributorTest(FSDPTest):
             fill=0.01,
             post_model_decoration=post_model_decoration,
         )
-        assert isinstance(model, nn.Module)
         if isinstance(distributed_config, FSDPShampooConfig):
             assert (
                 sum(param.numel() for param in model.parameters())
@@ -134,7 +133,6 @@ class ShampooFSDPDistributorTest(FSDPTest):
             ),
             num_steps=steps_with_gradients,
         )
-        assert isinstance(model, nn.Module)
 
         steps_without_gradients = 3
         for _ in range(steps_without_gradients):

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_utils_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_utils_test.py
@@ -38,7 +38,6 @@ def _create_model_and_params(
         enable_learnable_scalar=False,  # Disable 0D learable parameter because FSDP doesn't support it.
         fill=(1.0, 2.0),
     )
-    assert isinstance(model, nn.Module)
     return model, list(model.parameters())
 
 

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -86,7 +86,6 @@ class ShampooHSDPDistributorTest(FSDPTest):
             fill=0.01,
             post_model_decoration=post_model_decoration,
         )
-        assert isinstance(model, nn.Module)
         if isinstance(distributed_config, HSDPShampooConfig):
             assert (
                 sum(param.numel() for param in model.parameters())
@@ -184,7 +183,6 @@ class ShampooHSDPDistributorTest(FSDPTest):
                 distributed_config=hsdp_config,
             ),
         )
-        assert isinstance(model, nn.Module)
         assert isinstance(optimizer, DistributedShampoo)
         state_dict = optimizer.distributed_state_dict(
             key_to_param=model.named_parameters()
@@ -240,7 +238,6 @@ class ShampooHSDPDistributorTest(FSDPTest):
             ),
             num_steps=steps_with_gradients,
         )
-        assert isinstance(model, nn.Module)
 
         steps_without_gradients = 3
         for _ in range(steps_without_gradients):
@@ -277,7 +274,6 @@ class ShampooHSDPDistributorTest(FSDPTest):
             ),
             distributed_config=hsdp_config,
         )[0]
-        assert isinstance(model, nn.Module)
 
         self.assertRaisesRegex(
             ValueError,

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
@@ -14,6 +14,7 @@ import unittest
 from collections.abc import Callable
 from functools import partial
 from itertools import filterfalse
+from typing import overload
 from unittest import mock
 
 import torch
@@ -57,6 +58,20 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
     def world_size(self) -> int:
         return 4
 
+    @overload
+    @staticmethod
+    def _construct_model(
+        post_model_decoration: Callable[[nn.Module], nn.Module] = lambda x: x,
+    ) -> tuple[nn.Module, nn.Module, torch.Tensor, torch.Tensor]: ...
+
+    @overload
+    @staticmethod
+    def _construct_model(
+        post_model_decoration: Callable[
+            [nn.Module], FSDPModule
+        ] = lambda x: fully_shard(x),
+    ) -> tuple[FSDPModule, nn.Module, torch.Tensor, torch.Tensor]: ...
+
     @staticmethod
     def _construct_model(
         post_model_decoration: Callable[
@@ -91,13 +106,15 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
         model_linear_layers_dims = (4 * PRECONDITIONER_DIM, 2 * PRECONDITIONER_DIM, 1)
         # model dead layers won't parpicipate in the training and thus don't have grads.
         model_dead_layers_dims = (PRECONDITIONER_DIM, 1)
-        return construct_training_problem(
+        # Using partial here to prevent Pyre complain on incompatible parameter type.
+        return partial(
+            construct_training_problem, post_model_decoration=post_model_decoration
+        )(
             model_linear_layers_dims=model_linear_layers_dims,
             model_dead_layers_dims=model_dead_layers_dims,
             enable_learnable_scalar=False,  # Disable 0D learable parameter because FSDP doesn't support it.
             device=torch.device("cuda"),
             fill=0.1,
-            post_model_decoration=post_model_decoration,
         )
 
     @staticmethod

--- a/distributed_shampoo/utils/tests/shampoo_distributor_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_distributor_test.py
@@ -25,15 +25,12 @@ PRECONDITIONER_DIM = 5
 
 class DistributorTest(unittest.TestCase):
     def setUp(self) -> None:
-        self._model: nn.Module = cast(
-            nn.Module,
-            construct_training_problem(
-                (2 * PRECONDITIONER_DIM, PRECONDITIONER_DIM),
-                model_dead_layers_dims=None,
-                bias=True,
-                fill=0.0,
-            )[0],
-        )
+        self._model: nn.Module = construct_training_problem(
+            (2 * PRECONDITIONER_DIM, PRECONDITIONER_DIM),
+            model_dead_layers_dims=None,
+            bias=True,
+            fill=0.0,
+        )[0]
         self._distributor = Distributor(
             param_group=DistributedShampoo(
                 self._model.parameters(),


### PR DESCRIPTION
Summary: Because those two functions's return types depend on the input types, using `typing.overload`, type checkers could understand the subtlety of types while checking. This helps removing some assertions which were added to prevent type checkers' complains.

Differential Revision: D75814249


