### PR TITLE
update norm computation for upcoming PyTorch update

### DIFF
--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -955,7 +955,9 @@ def compute_matrix_root_inverse_residuals(
         root_inv_config=root_inv_config,
         epsilon=epsilon,
     )
-    relative_error = torch.dist(X, X_hat, p=torch.inf) / torch.norm(X, p=torch.inf)
+    relative_error = torch.dist(X, X_hat, p=torch.inf) / torch.linalg.vector_norm(
+        X, ord=torch.inf
+    )
 
     # compute residual
     X_invr, _, _ = _matrix_inverse_root_eigen(
@@ -970,8 +972,8 @@ def compute_matrix_root_inverse_residuals(
     A_reg = A.double() + epsilon * torch.eye(
         A.shape[0], dtype=torch.float64, device=A.device
     )
-    relative_residual = torch.dist(X_invr, A_reg, p=torch.inf) / torch.norm(
-        A_reg, p=torch.inf
-    )
+    relative_residual = torch.dist(
+        X_invr, A_reg, p=torch.inf
+    ) / torch.linalg.vector_norm(A_reg, ord=torch.inf)
 
     return relative_error, relative_residual


### PR DESCRIPTION
This updates replace `torch.norm()` with `torch.linalg.vector_norm()` for upcoming PyTorch update.

Based on [PyTorch - docs](https://docs.pytorch.org/docs/stable/generated/torch.norm.html), `torch.norm()` will no longer be used

Following is the test code:
```python
import torch

# Create test tensors
torch.manual_seed(42)
X = torch.randn(10, 10)
X_hat, A_reg = torch.randn(10, 10), torch.randn(5, 5)

print("X shape:", X.shape)
print("A_reg shape:", A_reg.shape)
print()

# Old Version (torch.norm)
print("=== Old Version (torch.norm) ===")
old_relative_error = torch.dist(X, X_hat, p=torch.inf) / torch.norm(X, p=torch.inf)
old_norm_result = torch.norm(A_reg, p=torch.inf)

print("Relative error:", old_relative_error.item())
print("A_reg infinity norm:", old_norm_result.item())
print()

# New Version (torch.linalg.vector_norm)
print("=== New Version (torch.linalg.vector_norm) ===")
new_relative_error = torch.dist(X, X_hat, p=torch.inf) / torch.linalg.vector_norm(X, ord=torch.inf)
new_norm_result = torch.linalg.vector_norm(A_reg, ord=torch.inf)

print("Relative error:", new_relative_error.item())
print("A_reg infinity norm:", new_norm_result.item())
print()

# Comparison
print("=== Comparison ===")
print("Relative error equal?", torch.allclose(old_relative_error, new_relative_error))
print("Norm results equal?", torch.allclose(old_norm_result, new_norm_result))
```

And the result is:
```bash
X shape: torch.Size([10, 10])
A_reg shape: torch.Size([5, 5])

=== Old Version (torch.norm) ===
Relative error: 1.512144684791565
A_reg infinity norm: 1.9775909185409546

=== New Version (torch.linalg.vector_norm) ===
Relative error: 1.512144684791565
A_reg infinity norm: 1.9775909185409546

=== Comparison ===
Relative error equal? True
Norm results equal? True
```