### PR TITLE
Open-sourced update on 06/10/2025

### DIFF
--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -94,7 +94,11 @@ from distributed_shampoo.utils.shampoo_preconditioner_list import (
     SGDPreconditionerList,
 )
 from distributed_shampoo.utils.shampoo_utils import compress_list
-from matrix_functions_types import EigendecompositionConfig, RootInvConfig
+from matrix_functions_types import (
+    EigendecompositionConfig,
+    PseudoInverseConfig,
+    RootInvConfig,
+)
 
 from torch.optim.optimizer import ParamsT, StateDict
 
@@ -341,7 +345,18 @@ class DistributedShampoo(torch.optim.Optimizer):
             raise ValueError(
                 f"Invalid beta3 parameter: {beta3}. Must be in [0.0, 1.0)."
             )
-        if not epsilon > 0.0:
+        if isinstance(
+            preconditioner_config.amortized_computation_config,
+            EigendecompositionConfig,
+        ) and isinstance(
+            preconditioner_config.amortized_computation_config.rank_deficient_stability_config,
+            PseudoInverseConfig,
+        ):
+            if epsilon != 0.0:
+                raise ValueError(
+                    f"Invalid epsilon value: {epsilon}. Must be == 0.0 when PseudoInverseConfig is used."
+                )
+        elif not epsilon > 0.0:
             raise ValueError(f"Invalid epsilon value: {epsilon}. Must be > 0.0.")
         if not 0.0 <= momentum < 1.0:
             raise ValueError(

--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -31,7 +31,11 @@ from distributed_shampoo.shampoo_types import (
     ShampooPreconditionerConfig,
     ShampooPT2CompileConfig,
 )
-from matrix_functions_types import DefaultEigendecompositionConfig, EigenConfig
+from matrix_functions_types import (
+    DefaultEigendecompositionConfig,
+    EigenConfig,
+    PseudoInverseConfig,
+)
 from torch import nn
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -98,6 +102,17 @@ class DistributedShampooInitTest(unittest.TestCase):
             (
                 {"epsilon": 0.0},
                 "Invalid epsilon value: 0.0. Must be > 0.0.",
+            ),
+            (
+                {
+                    "epsilon": 0.1,
+                    "preconditioner_config": ShampooPreconditionerConfig(
+                        amortized_computation_config=EigenConfig(
+                            rank_deficient_stability_config=PseudoInverseConfig()
+                        )
+                    ),
+                },
+                "Invalid epsilon value: 0.1. Must be == 0.0 when PseudoInverseConfig is used.",
             ),
             (
                 {"momentum": 3.14},

--- a/tests/matrix_functions_test.py
+++ b/tests/matrix_functions_test.py
@@ -146,8 +146,9 @@ class StabilizeAndPowEigenvaluesTest(unittest.TestCase):
             ),
         )
 
+    @parametrize("perturb_before_computation", (True, False))
     def test_stabilize_and_pow_eigenvalues_perturbation_after_with_disportionate_epsilon(
-        self,
+        self, perturb_before_computation: bool
     ) -> None:
         # This test verifies that stabilize_and_pow_eigenvalues handles matrices with large values correctly
         # Note that the smallest entries in L have absolute magnitude of 100000.0, which is much larger
@@ -165,7 +166,7 @@ class StabilizeAndPowEigenvaluesTest(unittest.TestCase):
             root=Fraction(2),
             epsilon=1e-5,
             rank_deficient_stability_config=PerturbationConfig(
-                perturb_before_computation=False,
+                perturb_before_computation=perturb_before_computation,
             ),
         )
         self.assertTrue(torch.isfinite(inv_power_L).all())


### PR DESCRIPTION
Summary:
1. Fix `stabilize_and_pow_eigenvalues(rank_deficient_stability_config=PerturbationConfig(perturb_before_computation=True))` in `matrix_functions.py` done by @gajjanag .
2. Relax the check on using pseudo-inverse done by @anana10c .

Differential Revision: D76238254


