### PR TITLE
Support distributed shampoo examples for internal runs

### DIFF
--- a/distributed_shampoo/examples/convnet.py
+++ b/distributed_shampoo/examples/convnet.py
@@ -7,6 +7,8 @@ LICENSE file in the root directory of this source tree.
 
 """
 
+#!/usr/bin/env python3
+
 import math
 
 import torch
@@ -40,8 +42,8 @@ class ConvNet(nn.Module):
     """
 
     def __init__(
-        self, height: int, width: int, channels: int, use_combined_linear=False
-    ):
+        self, height: int, width: int, channels: int, use_combined_linear: bool = False
+    ) -> None:
         super(ConvNet, self).__init__()
         self.conv = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
         self.activation = nn.ReLU()
@@ -55,5 +57,5 @@ class ConvNet(nn.Module):
             10,
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear(torch.flatten(self.activation(self.conv(x)), 1))

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -7,6 +7,9 @@ LICENSE file in the root directory of this source tree.
 
 """
 
+#!/usr/bin/env python3
+
+import argparse
 import logging
 import os
 
@@ -21,12 +24,13 @@ from distributed_shampoo.examples.trainer_utils import (
     set_seed,
 )
 from torch import nn
+from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
     level=logging.DEBUG,
 )
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
@@ -93,7 +97,7 @@ if __name__ == "__main__":
     """
 
     # parse arguments
-    args = Parser.get_args()
+    args: argparse.Namespace = Parser.get_args()
 
     # set seed for reproducibility
     set_seed(args.seed)
@@ -102,14 +106,18 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     # instantiate model and loss function
+    model: nn.Module
+    loss_function: nn.Module
     model, loss_function = get_model_and_loss_fn(device)
 
     # instantiate data loader. Note that this is a single GPU training example,
     # so we do not need to instantiate a sampler.
+    data_loader: torch.utils.data.DataLoader[VisionDataset]
+    # type: ignore
     data_loader, _ = get_data_loader_and_sampler(args.data_path, 1, 0, args.batch_size)
 
     # instantiate optimizer (SGD, Adam, DistributedShampoo)
-    optimizer = instantiate_optimizer(
+    optimizer: torch.optim.Optimizer = instantiate_optimizer(
         args.optimizer_type,
         model,
         lr=args.lr,

--- a/distributed_shampoo/examples/fsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/fsdp_cifar10_example.py
@@ -7,8 +7,13 @@ LICENSE file in the root directory of this source tree.
 
 """
 
+#!/usr/bin/env python3
+
+import argparse
 import logging
 import os
+
+import torch
 
 import torch.distributed as dist
 
@@ -22,13 +27,15 @@ from distributed_shampoo.examples.trainer_utils import (
     setup_distribution,
     train_model,
 )
+from torch import nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
     level=logging.DEBUG,
 )
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
@@ -66,13 +73,13 @@ if __name__ == "__main__":
 
     """
 
-    args = Parser.get_args()
+    args: argparse.Namespace = Parser.get_args()
 
     # set seed for reproducibility
     set_seed(args.seed)
 
     # initialize distributed process group
-    device = setup_distribution(
+    device: torch.device = setup_distribution(
         backend=args.backend,
         world_rank=WORLD_RANK,
         world_size=WORLD_SIZE,
@@ -80,16 +87,22 @@ if __name__ == "__main__":
     )
 
     # instantiate model and loss function
+    model: nn.Module
+    loss_function: nn.Module
     model, loss_function = get_model_and_loss_fn(device)
     model = FSDP(model, use_orig_params=True)
 
     # instantiate data loader
+    data_loader: torch.utils.data.DataLoader[VisionDataset]
+    sampler: torch.utils.data.distributed.DistributedSampler[
+        torch.utils.data.Dataset[VisionDataset]
+    ]
     data_loader, sampler = get_data_loader_and_sampler(
         args.data_path, WORLD_SIZE, WORLD_RANK, args.local_batch_size
     )
 
     # instantiate optimizer (SGD, Adam, DistributedShampoo)
-    optimizer = instantiate_optimizer(
+    optimizer: torch.optim.Optimizer = instantiate_optimizer(
         args.optimizer_type,
         model,
         lr=args.lr,

--- a/matrix_functions.py
+++ b/matrix_functions.py
@@ -481,7 +481,9 @@ def _eigh_eigenvalue_decomposition(
             # If retry_double_precision is False or the computation fails in double precision, raise the exception
             raise exception
 
-    return L.to(device=current_device), Q.to(device=current_device, dtype=A.dtype)
+    return L.to(device=current_device, dtype=A.dtype), Q.to(
+        device=current_device, dtype=A.dtype
+    )
 
 
 def _eigenvalues_estimate_criterion_below_or_equal_tolerance(


### PR DESCRIPTION
Summary:
Make distributed shampoo examples work internally on local devservers and MAST, by BUCK-ifying the OSS-only example files and import path conversion.

Differential Revision: D76478106
