### PR TITLE
Support metrics export for distributed shampoo examples

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -184,6 +184,7 @@ if __name__ == "__main__":
         epochs=args.epochs,
         window_size=args.window_size,
         local_rank=LOCAL_RANK,
+        metrics_dir=args.metrics_dir if WORLD_RANK == 0 else None,
     )
 
     # checkpoint optimizer and model using distributed checkpointing solution

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -45,11 +45,14 @@ def train_default_model(
     device: torch.device,
     epochs: int = 1,
     window_size: int = 100,
+    metrics_dir: str | None = None,
 ) -> tuple[float, float, int]:
     """Constructs the main training loop."""
 
     # initialize metrics
-    metrics = LossMetrics(window_size=window_size, device=device)
+    metrics = LossMetrics(
+        window_size=window_size, device=device, metrics_dir=metrics_dir
+    )
 
     # main training loop
     for epoch in range(epochs):
@@ -64,6 +67,7 @@ def train_default_model(
             metrics.update(loss)
             metrics.log()
 
+    metrics.flush()
     return (
         metrics._lifetime_loss.item(),
         metrics._window_loss.item(),
@@ -152,4 +156,5 @@ if __name__ == "__main__":
         device,
         epochs=args.epochs,
         window_size=args.window_size,
+        metrics_dir=args.metrics_dir,
     )

--- a/distributed_shampoo/examples/fsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/fsdp_cifar10_example.py
@@ -142,6 +142,7 @@ if __name__ == "__main__":
         epochs=args.epochs,
         window_size=args.window_size,
         local_rank=LOCAL_RANK,
+        metrics_dir=args.metrics_dir if WORLD_RANK == 0 else None,
     )
 
     # clean up process group

--- a/distributed_shampoo/examples/fully_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/fully_shard_cifar10_example.py
@@ -59,6 +59,7 @@ def train_fully_shard_model(
     window_size: int = 100,
     use_distributed_checkpoint: bool = False,
     checkpoint_dir: str | None = None,
+    metrics_dir: str | None = None,
 ) -> tuple[float, float, int]:
     """Constructs the main training loop.
 
@@ -67,7 +68,12 @@ def train_fully_shard_model(
     """
 
     # initialize metrics
-    metrics = LossMetrics(window_size=window_size, device=device, world_size=world_size)
+    metrics = LossMetrics(
+        window_size=window_size,
+        device=device,
+        world_size=world_size,
+        metrics_dir=metrics_dir,
+    )
 
     # main training loop
     for epoch in range(epochs):
@@ -102,6 +108,7 @@ def train_fully_shard_model(
             storage_writer=dist_checkpoint.FileSystemWriter(checkpoint_dir),
         )
 
+    metrics.flush()
     return (
         metrics._lifetime_loss.item(),
         metrics._window_loss.item(),
@@ -212,6 +219,7 @@ if __name__ == "__main__":
         window_size=args.window_size,
         use_distributed_checkpoint=args.use_distributed_checkpoint,
         checkpoint_dir=args.checkpoint_dir,
+        metrics_dir=args.metrics_dir if WORLD_RANK == 0 else None,
     )
 
     # clean up process group

--- a/distributed_shampoo/examples/hsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/hsdp_cifar10_example.py
@@ -157,6 +157,7 @@ if __name__ == "__main__":
         epochs=args.epochs,
         window_size=args.window_size,
         local_rank=LOCAL_RANK,
+        metrics_dir=args.metrics_dir if WORLD_RANK == 0 else None,
     )
 
     # clean up process group

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 [project.optional-dependencies]
 examples = [
   "torchvision>=0.15.0",
+  "tensorboard>=2.12.0",
 ]
 
 dev = [


### PR DESCRIPTION
Summary:
This change allows users to optionally specify a metrics directory to export metrics, in addition to logging them to stdout. This enables metrics visualization through TensorBoard and simplifies the process of metrics comparison between different runs.

Internally, jobs launched through `torchx` will have the TensorBoard tab populated with metrics history.

Differential Revision: D76760971
