### PR TITLE
Simplify `get_all_subclasses()` to focus on getting instantiable subclasses

### DIFF
--- a/commons.py
+++ b/commons.py
@@ -62,21 +62,18 @@ class AbstractDataclass(ABC):
 _SubclassesType = TypeVar("_SubclassesType")
 
 
-def get_all_subclasses(
-    cls: _SubclassesType, include_cls_self: bool = True
-) -> list[_SubclassesType]:
+def get_all_non_abstract_subclasses(cls: _SubclassesType) -> Iterable[_SubclassesType]:
     """
-    Retrieves all subclasses of a given class, optionally including the class itself.
+    Retrieves all non-abstract (instantiable) subclasses of a given class.
 
     This function uses a helper function to recursively find all unique subclasses
-    of the specified class.
+    of the specified class, and then filters out any abstract classes.
 
     Args:
-        cls (SubclassesType): The class for which to find subclasses.
-        include_cls_self (bool): Whether to include the class itself in the result. (Default: True)
+        cls (_SubclassesType): The class for which to find subclasses.
 
     Returns:
-        list[SubclassesType]: A list of all unique subclasses of the given class.
+        non_abstract_subclasses (Iterable[_SubclassesType]): An iterable of all unique non-abstract subclasses of the given class.
     """
 
     def get_all_unique_subclasses(cls: _SubclassesType) -> set[_SubclassesType]:
@@ -87,7 +84,11 @@ def get_all_subclasses(
             {cls},
         )
 
-    return list(get_all_unique_subclasses(cls) - (set() if include_cls_self else {cls}))
+    return filter(
+        # Filters out abstract classes by checking if '__abstractmethods__' is an empty set or not present.
+        lambda sub_cls: not getattr(sub_cls, "__abstractmethods__", frozenset()),
+        get_all_unique_subclasses(cls),
+    )
 
 
 _BatchedInputType = TypeVar("_BatchedInputType")

--- a/distributed_shampoo/tests/shampoo_types_test.py
+++ b/distributed_shampoo/tests/shampoo_types_test.py
@@ -10,7 +10,7 @@ LICENSE file in the root directory of this source tree.
 import re
 import unittest
 
-from commons import get_all_subclasses
+from commons import get_all_non_abstract_subclasses
 
 from distributed_shampoo.shampoo_types import (
     AdaGradGraftingConfig,
@@ -27,8 +27,8 @@ from torch.testing._internal.common_utils import (
 
 @instantiate_parametrized_tests
 class AdaGradGraftingConfigSubclassesTest(unittest.TestCase):
-    subclasses_types: list[type[AdaGradGraftingConfig]] = get_all_subclasses(
-        AdaGradGraftingConfig
+    subclasses_types: list[type[AdaGradGraftingConfig]] = list(
+        get_all_non_abstract_subclasses(AdaGradGraftingConfig)
     )
 
     @parametrize("epsilon", (0.0, -1.0))
@@ -46,8 +46,8 @@ class AdaGradGraftingConfigSubclassesTest(unittest.TestCase):
 
 @instantiate_parametrized_tests
 class RMSpropGraftingConfigSubclassesTest(unittest.TestCase):
-    subclasses_types: list[type[RMSpropGraftingConfig]] = get_all_subclasses(
-        RMSpropGraftingConfig
+    subclasses_types: list[type[RMSpropGraftingConfig]] = list(
+        get_all_non_abstract_subclasses(RMSpropGraftingConfig)
     )
 
     @parametrize("beta2", (-1.0, 0.0, 1.3))
@@ -67,9 +67,10 @@ class RMSpropGraftingConfigSubclassesTest(unittest.TestCase):
 
 @instantiate_parametrized_tests
 class PreconditionerConfigSubclassesTest(unittest.TestCase):
-    subclasses_types: list[type[PreconditionerConfig]] = get_all_subclasses(
-        PreconditionerConfig,  # type: ignore[type-abstract]
-        include_cls_self=False,
+    subclasses_types: list[type[PreconditionerConfig]] = list(
+        get_all_non_abstract_subclasses(
+            PreconditionerConfig,  # type: ignore[type-abstract]
+        )
     )
 
     # Not testing for the base class PreconditionerConfig because it is an abstract class.
@@ -91,8 +92,10 @@ class PreconditionerConfigSubclassesTest(unittest.TestCase):
 
 @instantiate_parametrized_tests
 class ShampooPreconditionerConfigSubclassesTest(unittest.TestCase):
-    subclasses_types: list[type[ShampooPreconditionerConfig]] = get_all_subclasses(
-        ShampooPreconditionerConfig, include_cls_self=True
+    subclasses_types: list[type[ShampooPreconditionerConfig]] = list(
+        get_all_non_abstract_subclasses(
+            ShampooPreconditionerConfig,
+        )
     )
 
     @parametrize("cls", subclasses_types)
@@ -156,10 +159,8 @@ class ShampooPreconditionerConfigSubclassesTest(unittest.TestCase):
 
 @instantiate_parametrized_tests
 class EigenvalueCorrectedShampooPreconditionerConfigSubclassesTest(unittest.TestCase):
-    subclasses_types: list[type[EigenvalueCorrectedShampooPreconditionerConfig]] = (
-        get_all_subclasses(
-            EigenvalueCorrectedShampooPreconditionerConfig, include_cls_self=True
-        )
+    subclasses_types: list[type[EigenvalueCorrectedShampooPreconditionerConfig]] = list(
+        get_all_non_abstract_subclasses(EigenvalueCorrectedShampooPreconditionerConfig)
     )
 
     @parametrize("cls", subclasses_types)

--- a/tests/matrix_functions_types_test.py
+++ b/tests/matrix_functions_types_test.py
@@ -12,7 +12,7 @@ import unittest
 
 import torch
 
-from commons import get_all_subclasses
+from commons import get_all_non_abstract_subclasses
 from matrix_functions_types import QREigendecompositionConfig
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -22,8 +22,8 @@ from torch.testing._internal.common_utils import (
 
 @instantiate_parametrized_tests
 class QREigendecompositionConfigSubclassesTest(unittest.TestCase):
-    subclasses_types: list[type[QREigendecompositionConfig]] = get_all_subclasses(
-        QREigendecompositionConfig
+    subclasses_types: list[type[QREigendecompositionConfig]] = list(
+        get_all_non_abstract_subclasses(QREigendecompositionConfig)
     )
 
     # tolerance has to be in the interval [0.0, 1.0].


### PR DESCRIPTION
Summary:
The goal of `get_all_subclasses()` is retrieving the subclasses (including class itself) which are instantiable classes; this is useful for testing checks in `dataclass.__post_init__()`. Previously the `include_cls_self` input argument is a half-baked approximation of this idea, and this diff simplify the implementation of `get_all_subclasses()` as follows:
1. Rename `get_all_subclasses()` to `get_all_non_abstract_subclasses()`.
2. Remove the `include_cls_self` input argument and incorporate @runame 's idea on detecting a class is an abstract class in this new implementation.

Differential Revision: D76996277


