### PR TITLE
Add missing `RootInvShampooPreconditionerConfig` symbol in `__init__.py`

### DIFF
--- a/distributed_shampoo/__init__.py
+++ b/distributed_shampoo/__init__.py
@@ -24,8 +24,8 @@ from distributed_shampoo.shampoo_types import (
     HybridShardShampooConfig,
     PreconditionerConfig,
     RMSpropGraftingConfig,
+    RootInvShampooPreconditionerConfig,
     SGDGraftingConfig,
-    ShampooPreconditionerConfig,
     ShampooPT2CompileConfig,
 )
 from distributed_shampoo.utils.shampoo_fsdp_utils import compile_fsdp_parameter_metadata
@@ -63,7 +63,7 @@ __all__ = [
     # `precision_config`.
     # `preconditioner_config` options.
     "PreconditionerConfig",  # Abstract base class.
-    "ShampooPreconditionerConfig",  # Based on `PreconditionerConfig`.
+    "RootInvShampooPreconditionerConfig",  # Based on `PreconditionerConfig`.
     "DefaultShampooConfig",  # Default `ShampooPreconditionerConfig` using `EigenConfig`.
     "EigenvalueCorrectedShampooPreconditionerConfig",  # Based on `PreconditionerConfig`.
     "DefaultEigenvalueCorrectedShampooConfig",  # Default `EigenvalueCorrectedShampooPreconditionerConfig` using `EighEigendecompositionConfig`.

--- a/distributed_shampoo/tests/shampoo_types_test.py
+++ b/distributed_shampoo/tests/shampoo_types_test.py
@@ -94,7 +94,7 @@ class PreconditionerConfigSubclassesTest(unittest.TestCase):
 class ShampooPreconditionerConfigSubclassesTest(unittest.TestCase):
     subclasses_types: list[type[ShampooPreconditionerConfig]] = list(
         get_all_non_abstract_subclasses(
-            ShampooPreconditionerConfig,
+            ShampooPreconditionerConfig,  # type: ignore[type-abstract]
         )
     )
 

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -1248,7 +1248,7 @@ class EigendecomposedShampooPreconditionerListTest(
         return EigendecompositionProperties()
 
     @property
-    def _default_preconditioner_config(
+    def _default_preconditioner_config(  # type: ignore[override]
         self,
     ) -> EigendecomposedShampooPreconditionerConfig:
         return EigendecomposedShampooPreconditionerConfig(


### PR DESCRIPTION
Summary:
In the commit
https://github.com/facebookresearch/optimizers/commit/717221c4de6ef31abee0ec80fa263fe124579dc9, we updated the configuration from `ShampooPreconditionerConfig` to `RootInvShampooPreconditionerConfig`. However, the `__init__.py` file also requires modification to ensure the proper functionality of the following modules. This diff addresses the necessary changes in `__init__.py` to support these updates.

This diff also fixes other type check complains and remove unused imports.

Differential Revision: D77191607


