### PR TITLE
Improve the test case of `all_ranks_with_no_grads`

### DIFF
--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -390,44 +390,31 @@ class AbstractTest:
         def test_all_ranks_with_no_grads(self, communicate_params: bool) -> None:
             self._init_distributed()
 
-            steps_with_gradients = 2
-            model, loss, data, target, optimizer = train_model(
-                optim_factory=AbstractTest.ShampooDDPDistributorDeviceTest._shampoo_optim_factory(
-                    distributed_config=DDPShampooConfig(
-                        communicate_params=communicate_params
-                    )
-                ),
-                # 4 * 2 blocks in total. Rank 0 and Rank 1 have 4 blocks each.
-                model_factory=partial(
-                    construct_training_problem,
-                    model_linear_layers_dims=(
-                        PRECONDITIONER_DIM * 4,
-                        PRECONDITIONER_DIM * 2,
+            steps_without_gradients = 2
+            with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+                # By mocking the backward() method, we're intercepting gradient calculation.
+                # This effectively simulates running forward passes without computing gradients.
+                train_model(
+                    optim_factory=AbstractTest.ShampooDDPDistributorDeviceTest._shampoo_optim_factory(
+                        distributed_config=DDPShampooConfig(
+                            communicate_params=communicate_params
+                        )
                     ),
-                    model_dead_layers_dims=None,
-                    device=self._device,
-                ),
-                num_steps=steps_with_gradients,
-            )
+                    # 4 * 2 blocks in total. Rank 0 and Rank 1 have 4 blocks each.
+                    model_factory=partial(
+                        construct_training_problem,
+                        model_linear_layers_dims=(
+                            PRECONDITIONER_DIM * 4,
+                            PRECONDITIONER_DIM * 2,
+                        ),
+                        model_dead_layers_dims=None,
+                        device=self._device,
+                    ),
+                    num_steps=steps_without_gradients,
+                )
 
-            steps_without_gradients = 3
-            for _ in range(steps_without_gradients):
-                objective = loss(model(data), target)
-                objective.backward()
-
-                # Experiment setup: all ranks get no gradients.
-                optimizer.zero_grad()
-
-                optimizer.step()
-
-            assert isinstance(optimizer, DistributedShampoo)
-            # For each rank, no matter getting gradients or not, the step should be updated.
-            self.assertEqual(
-                optimizer.distributed_state_dict(key_to_param=model.named_parameters())[
-                    "state"
-                ]["scalar"]['["step"]'].item(),
-                steps_with_gradients + steps_without_gradients,
-            )
+            # Verify that the backward() method was called the expected number of times and the training loop completed successfully.
+            self.assertEqual(mock_backward.call_count, steps_without_gradients)
 
         @parametrize("communicate_params", (False, True))
         def test_some_ranks_with_no_grads_due_to_dead_layers(

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fully_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fully_shard_distributor_test.py
@@ -128,38 +128,23 @@ class ShampooFullyShardDistributorTest(DTensorTestBase):
     def test_all_ranks_with_no_grads(self) -> None:
         fully_shard_config = FullyShardShampooConfig()  # type: ignore[abstract]
 
-        steps_with_gradients = 2
-        model, loss, data, target, optimizer = train_model(
-            optim_factory=ShampooFullyShardDistributorTest._shampoo_optim_factory(
-                distributed_config=fully_shard_config,
-            ),
-            model_factory=partial(
-                ShampooFullyShardDistributorTest._construct_model,
-                post_model_decoration=partial(fully_shard),
-            ),
-            num_steps=steps_with_gradients,
-        )
+        steps_without_gradients = 2
+        with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+            # By mocking the backward() method, we're intercepting gradient calculation.
+            # This effectively simulates running forward passes without computing gradients.
+            train_model(
+                optim_factory=ShampooFullyShardDistributorTest._shampoo_optim_factory(
+                    distributed_config=fully_shard_config,
+                ),
+                model_factory=partial(
+                    ShampooFullyShardDistributorTest._construct_model,
+                    post_model_decoration=partial(fully_shard),
+                ),
+                num_steps=steps_without_gradients,
+            )
 
-        steps_without_gradients = 3
-        for _ in range(steps_without_gradients):
-            assert isinstance(model, nn.Module)
-            objective = loss(model(data), target)
-            objective.backward()
-
-            # Experiment setup: all ranks get no gradients.
-            optimizer.zero_grad()
-
-            optimizer.step()
-
-        assert isinstance(model, nn.Module)
-        assert isinstance(optimizer, DistributedShampoo)
-        # For each rank, no matter getting gradients or not, the step should be updated.
-        self.assertEqual(
-            optimizer.distributed_state_dict(key_to_param=model.named_parameters())[
-                "state"
-            ]["linear_layers.0.weight"]['["step"]'].item(),
-            steps_with_gradients + steps_without_gradients,
-        )
+        # Verify that the backward() method was called the expected number of times and the training loop completed successfully.
+        self.assertEqual(mock_backward.call_count, steps_without_gradients)
 
     @with_comms
     @skip_if_lt_x_gpu(2)

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -221,42 +221,29 @@ class ShampooHSDPDistributorTest(FSDPTest):
             communicate_params=communicate_params,
         )
 
-        steps_with_gradients = 2
-        model, loss, data, target, optimizer = train_model(
-            optim_factory=ShampooHSDPDistributorTest._shampoo_optim_factory(
-                distributed_config=hsdp_config
-            ),
-            model_factory=partial(
-                ShampooHSDPDistributorTest._construct_model,
-                post_model_decoration=partial(
-                    FSDP1,
-                    device_mesh=hsdp_config.device_mesh,
-                    sharding_strategy=ShardingStrategy.HYBRID_SHARD,
-                    use_orig_params=True,
+        steps_without_gradients = 2
+        with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+            # By mocking the backward() method, we're intercepting gradient calculation.
+            # This effectively simulates running forward passes without computing gradients.
+            train_model(
+                optim_factory=ShampooHSDPDistributorTest._shampoo_optim_factory(
+                    distributed_config=hsdp_config
                 ),
-                distributed_config=hsdp_config,
-            ),
-            num_steps=steps_with_gradients,
-        )
+                model_factory=partial(
+                    ShampooHSDPDistributorTest._construct_model,
+                    post_model_decoration=partial(
+                        FSDP1,
+                        device_mesh=hsdp_config.device_mesh,
+                        sharding_strategy=ShardingStrategy.HYBRID_SHARD,
+                        use_orig_params=True,
+                    ),
+                    distributed_config=hsdp_config,
+                ),
+                num_steps=steps_without_gradients,
+            )
 
-        steps_without_gradients = 3
-        for _ in range(steps_without_gradients):
-            objective = loss(model(data), target)
-            objective.backward()
-
-            # Experiment setup: all ranks get no gradients.
-            optimizer.zero_grad()
-
-            optimizer.step()
-
-        assert isinstance(optimizer, DistributedShampoo)
-        # For each rank, no matter getting gradients or not, the step should be updated.
-        self.assertEqual(
-            optimizer.distributed_state_dict(key_to_param=model.named_parameters())[
-                "state"
-            ]["_fsdp_wrapped_module.linear_layers.0.weight"]['["step"]'].item(),
-            steps_with_gradients + steps_without_gradients,
-        )
+        # Verify that the backward() method was called the expected number of times and the training loop completed successfully.
+        self.assertEqual(mock_backward.call_count, steps_without_gradients)
 
     @skip_if_lt_x_gpu(4)
     def test_number_of_trainers_per_group_out_of_range(self) -> None:


### PR DESCRIPTION
Summary: By mocking the `backward()` process, we effectively intercept the gradient calculation, which simulates a no gradient scenario for testing how Shampoo reacts on this.

Differential Revision: D77518777


