### PR TITLE
Fix mypy complains on e0835ae512366bb63e1503934ee5345bf69ef71a

### DIFF
--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -1367,7 +1367,7 @@ class EigendecomposedShampooPreconditionerListTest(
         return EigendecomposedShampooPreconditionerList
 
     @property
-    def _preconditioner_config_with_adaptive_amortized_computation_frequency(
+    def _preconditioner_config_with_adaptive_amortized_computation_frequency(  # type: ignore[override]
         self,
     ) -> EigendecomposedShampooPreconditionerConfig:
         return EigendecomposedShampooPreconditionerConfig(

--- a/tests/matrix_functions_types_test.py
+++ b/tests/matrix_functions_types_test.py
@@ -23,7 +23,9 @@ from torch.testing._internal.common_utils import (
 @instantiate_parametrized_tests
 class EigendecompositionConfigSubclassesTest(unittest.TestCase):
     subclasses_types: list[type[EigendecompositionConfig]] = list(
-        get_all_non_abstract_subclasses(EigendecompositionConfig)
+        get_all_non_abstract_subclasses(
+            EigendecompositionConfig  # type: ignore[type-abstract]
+        )
     )
 
     # tolerance has to be in the interval [0.0, 1.0].


### PR DESCRIPTION
Summary: Add corresponding `type: ignore` statements to prevent the complains from mypy.

Differential Revision: D77560368


