### PR TITLE
Add test for FSDPDistributor on empty params

### DIFF
--- a/distributed_shampoo/tests/shampoo_test_utils.py
+++ b/distributed_shampoo/tests/shampoo_test_utils.py
@@ -46,6 +46,9 @@ class _ModelWithScalarAndLinearAndDeadLayers(nn.Module):
                     for a, b in pairwise(model_dead_layers_dims)
                 )
             )
+            # Initialize dead layers with zeros for the ease of testing if needed
+            for m in self.dead_layers:
+                m.weight.data.fill_(0.0)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear_layers(x) + self.scalar


### PR DESCRIPTION
Summary: This diff adds tests on how `FSDPDistributor` reacts on empty params. This is a continuation of https://github.com/facebookresearch/optimizers/commit/3779692c4b7dc2f2d28f3337b1f1e1e1f16fd986.

Differential Revision: D77615934


