### PR TITLE
Add matrix_orthogonalization function with SVD and Newton-Schulz option

### DIFF
--- a/distributed_shampoo/__init__.py
+++ b/distributed_shampoo/__init__.py
@@ -36,16 +36,20 @@ from matrix_functions_types import (
     CoupledNewtonConfig,
     DefaultEigenConfig,
     DefaultEigendecompositionConfig,
+    DefaultNewtonSchulzOrthogonalizationConfig,
     DefaultPerturbationConfig,
     EigenConfig,
     EigendecompositionConfig,
     EighEigendecompositionConfig,
     MatrixFunctionConfig,
+    NewtonSchulzOrthogonalizationConfig,
+    OrthogonalizationConfig,
     PerturbationConfig,
     PseudoInverseConfig,
     QREigendecompositionConfig,
     RankDeficientStabilityConfig,
     RootInvConfig,
+    SVDOrthogonalizationConfig,
 )
 
 
@@ -91,6 +95,10 @@ __all__ = [
     "DefaultEigenConfig",  # Default `RootInvConfig` using `EigenConfig`.
     "CoupledNewtonConfig",  # Based on `RootInvConfig`.
     "CoupledHigherOrderConfig",  # Based on `RootInvConfig`.
+    "OrthogonalizationConfig",  # Abstract base class (based on `MatrixFunctionConfig`).
+    "SVDOrthogonalizationConfig",  # Based on `OrthogonalizationConfig`.
+    "NewtonSchulzOrthogonalizationConfig",  # Based on `OrthogonalizationConfig`.
+    "DefaultNewtonSchulzOrthogonalizationConfig",  # Default `OrthogonalizationConfig` using `NewtonSchulzOrthogonalizationConfig`.
     # Other utilities.
     "compile_fsdp_parameter_metadata",  # For `FSDPShampooConfig` and `HSDPShampooConfig`.
 ]


### PR DESCRIPTION
Summary: This diff adds a `matrix_orthogonalization` function with corresponding configs based on an `OrthogonalizationConfig` base class. The implemented options are `SVDOrthogonalizationConfig` and `NewtonSchulzOrthogonalizationConfig`.

Reviewed By: tsunghsienlee, hjmshi

Differential Revision: D77905496


