### PR TITLE
Config mypy setting to follow untyped imports

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -31,7 +31,7 @@ from distributed_shampoo.examples.trainer_utils import (
     train_model,
 )
 from torch import nn
-from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
+from torchvision.datasets import VisionDataset
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -24,7 +24,7 @@ from distributed_shampoo.examples.trainer_utils import (
     set_seed,
 )
 from torch import nn
-from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
+from torchvision.datasets import VisionDataset
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",

--- a/distributed_shampoo/examples/fsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/fsdp_cifar10_example.py
@@ -30,7 +30,7 @@ from distributed_shampoo.examples.trainer_utils import (
 )
 from torch import nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
+from torchvision.datasets import VisionDataset
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",

--- a/distributed_shampoo/examples/fully_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/fully_shard_cifar10_example.py
@@ -30,7 +30,7 @@ from distributed_shampoo.examples.trainer_utils import (
 from torch import nn
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed.fsdp import FSDPModule
-from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
+from torchvision.datasets import VisionDataset
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",

--- a/distributed_shampoo/examples/hsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/hsdp_cifar10_example.py
@@ -32,7 +32,7 @@ from distributed_shampoo.examples.trainer_utils import (
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
-from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
+from torchvision.datasets import VisionDataset
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",

--- a/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
@@ -32,7 +32,7 @@ from torch import nn
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.fsdp import FSDPModule
-from torchvision.datasets import VisionDataset  # type: ignore[import-untyped]
+from torchvision.datasets import VisionDataset
 
 logging.basicConfig(
     format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",

--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -49,7 +49,7 @@ from torch.distributed import checkpoint as dist_checkpoint
 from torch.distributed.fsdp import FSDPModule, fully_shard
 from torch.optim.optimizer import ParamsT
 from torch.utils.tensorboard import SummaryWriter
-from torchvision import datasets, transforms  # type: ignore[import-untyped]
+from torchvision import datasets, transforms
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
 Repository = "https://github.com/facebookresearch/optimizers.git"
 "Bug Tracker" = "https://github.com/facebookresearch/optimizers/issues"
 
+[tool.mypy]
+follow_untyped_imports = true
+
 [tool.setuptools]
 include-package-data = false
 py-modules = [


### PR DESCRIPTION
Summary: https://mypy.readthedocs.io/en/stable/config_file.html#confval-follow_untyped_imports is exactly the option for us to resolve the `import-untyped` mypy complains.

Differential Revision: D78243826


