### PR TITLE
Merge the warning messages and fix the mypy complains when using `SpectralDescentPreconditionerConfig`

### DIFF
--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -394,11 +394,7 @@ class DistributedShampoo(torch.optim.Optimizer):
             # Warn about hyperparameters that won't have any effect.
             logger.warning(
                 f"{betas[1]=} does not have any effect when SpectralDescentPreconditionerConfig is used."
-            )
-            logger.warning(
                 f"{epsilon=} does not have any effect when SpectralDescentPreconditionerConfig is used."
-            )
-            logger.warning(
                 f"{precondition_frequency=} does not have any effect when SpectralDescentPreconditionerConfig is used. Setting precondition_frequency to 1..."
             )
             precondition_frequency = 1
@@ -554,13 +550,18 @@ class DistributedShampoo(torch.optim.Optimizer):
                     | EigendecomposedShampooPreconditionerConfig()
                     | EigenvalueCorrectedShampooPreconditionerConfig()
                 ):
+                    preconditioner_config_to_list_cls: dict[
+                        type[PreconditionerConfig], Callable[..., PreconditionerList]
+                    ] = {
+                        RootInvShampooPreconditionerConfig: RootInvShampooPreconditionerList,
+                        EigendecomposedShampooPreconditionerConfig: EigendecomposedShampooPreconditionerList,
+                        EigenvalueCorrectedShampooPreconditionerConfig: EigenvalueCorrectedShampooPreconditionerList,
+                    }
                     preconditioner_list_cls: Callable[..., PreconditionerList] = (
-                        partial(  # type: ignore[assignment]
-                            {
-                                RootInvShampooPreconditionerConfig: RootInvShampooPreconditionerList,
-                                EigendecomposedShampooPreconditionerConfig: EigendecomposedShampooPreconditionerList,
-                                EigenvalueCorrectedShampooPreconditionerConfig: EigenvalueCorrectedShampooPreconditionerList,
-                            }[type(group[PRECONDITIONER_CONFIG])],  # type: ignore[index]
+                        partial(
+                            preconditioner_config_to_list_cls[
+                                type(group[PRECONDITIONER_CONFIG])
+                            ],
                             state=self.state,
                             block_info_list=state_lists[
                                 DISTRIBUTOR

--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -174,28 +174,14 @@ class DistributedShampooInitTest(unittest.TestCase):
             (
                 {
                     "betas": (0.9, 0.999),
-                    "preconditioner_config": DefaultSpectralDescentPreconditionerConfig,
-                    # Has to be set to False because otherwise parameter will be reshaped to 1D and initialization of preconditioner list will fail.
-                    "use_merge_dims": False,
-                },
-                "betas[1]=0.999 does not have any effect when SpectralDescentPreconditionerConfig is used.",
-            ),
-            (
-                {
                     "epsilon": 1e-8,
-                    "preconditioner_config": DefaultSpectralDescentPreconditionerConfig,
-                    # Has to be set to False because otherwise parameter will be reshaped to 1D and initialization of preconditioner list will fail.
-                    "use_merge_dims": False,
-                },
-                "epsilon=1e-08 does not have any effect when SpectralDescentPreconditionerConfig is used.",
-            ),
-            (
-                {
                     "precondition_frequency": 100,
                     "preconditioner_config": DefaultSpectralDescentPreconditionerConfig,
                     # Has to be set to False because otherwise parameter will be reshaped to 1D and initialization of preconditioner list will fail.
                     "use_merge_dims": False,
                 },
+                "betas[1]=0.999 does not have any effect when SpectralDescentPreconditionerConfig is used."
+                "epsilon=1e-08 does not have any effect when SpectralDescentPreconditionerConfig is used."
                 "precondition_frequency=100 does not have any effect when SpectralDescentPreconditionerConfig is used. Setting precondition_frequency to 1...",
             ),
         ],


### PR DESCRIPTION
Summary: 
1. No need to have separate warning messages when we could log those in one statement with line breaks.
2. Fix the mypy complains by explicitly type hints the dispatching dictionary.

Differential Revision: D78252178


