### PR TITLE
Remove redundant `Metrics` abstract class

### DIFF
--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -15,7 +15,6 @@ import importlib
 import logging
 import random
 import shutil
-from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import partial
 from operator import attrgetter
@@ -303,18 +302,7 @@ class Parser:
 
 
 ###### METRICS CLASSES ######
-class Metrics(ABC):
-    @abstractmethod
-    def log(self) -> None: ...
-
-    @abstractmethod
-    def reset(self) -> None: ...
-
-    @abstractmethod
-    def update(self, loss: torch.Tensor) -> None: ...
-
-
-class LossMetrics(Metrics):
+class LossMetrics:
     def __init__(
         self,
         window_size: int = 100,


### PR DESCRIPTION
Summary: There is no need to use `Metrics`, an abstract class, here when there is one concrete `LossMetrics` using it.

Differential Revision: D77746987


