### PR TITLE
Fix mypy complains on `EmptyParamsTest`

### DIFF
--- a/distributed_shampoo/utils/gpu_tests/distributor_test_utils.py
+++ b/distributed_shampoo/utils/gpu_tests/distributor_test_utils.py
@@ -131,6 +131,7 @@ class DistributorOnEmptyParamTest:
                     msg=f"Difference found at {index=}: {a.composable_block_ids=} != {b.composable_block_ids=}",
                 )
 
+        @property
         @abc.abstractmethod
         def _expected_local_masked_block_grads(self) -> tuple[torch.Tensor, ...]:
             """Returns expected local masked block gradients used in test_merge_and_block_gradients"""

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fully_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fully_shard_distributor_test.py
@@ -231,6 +231,7 @@ class FullyShardDistributorOnEmptyParamTest(
             post_model_decoration=partial(fully_shard),
         )[0]
         distributed_config = FullyShardShampooConfig()  # type: ignore[abstract]
+        assert isinstance(model, nn.Module)
         distributor = FullyShardDistributor(
             param_group=DistributedShampoo(
                 model.parameters(),
@@ -268,7 +269,7 @@ class FullyShardDistributorOnEmptyParamTest(
         return ()
 
     @with_comms
-    def test_update_params(self) -> None:
+    def test_update_params(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_update_params(self)
 
     @property
@@ -276,7 +277,7 @@ class FullyShardDistributorOnEmptyParamTest(
         return (False, False)
 
     @with_comms
-    def test_local_grad_selector(self) -> None:
+    def test_local_grad_selector(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_local_grad_selector(self)
 
     @property
@@ -296,7 +297,7 @@ class FullyShardDistributorOnEmptyParamTest(
         )
 
     @with_comms
-    def test_local_blocked_params(self) -> None:
+    def test_local_blocked_params(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_local_blocked_params(self)
 
     def _expected_local_block_info_list(
@@ -321,7 +322,7 @@ class FullyShardDistributorOnEmptyParamTest(
         )
 
     @with_comms
-    def test_local_block_info_list(self) -> None:
+    def test_local_block_info_list(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_local_block_info_list(self)
 
     @property
@@ -329,5 +330,5 @@ class FullyShardDistributorOnEmptyParamTest(
         return ()
 
     @with_comms
-    def test_merge_and_block_gradients(self) -> None:
+    def test_merge_and_block_gradients(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_merge_and_block_gradients(self)

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
@@ -544,6 +544,7 @@ class HybridShardDistributorOnEmptyParamTest(
         distributed_config = HybridShardShampooConfig(
             device_mesh=device_mesh, num_trainers_per_group=1
         )
+        assert isinstance(model, nn.Module)
         distributor = HybridShardDistributor(
             param_group=DistributedShampoo(
                 model.parameters(),
@@ -582,7 +583,7 @@ class HybridShardDistributorOnEmptyParamTest(
         return ()
 
     @with_comms
-    def test_update_params(self) -> None:
+    def test_update_params(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_update_params(self)
 
     @property
@@ -590,7 +591,7 @@ class HybridShardDistributorOnEmptyParamTest(
         return (False, False)
 
     @with_comms
-    def test_local_grad_selector(self) -> None:
+    def test_local_grad_selector(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_local_grad_selector(self)
 
     @property
@@ -610,7 +611,7 @@ class HybridShardDistributorOnEmptyParamTest(
         )
 
     @with_comms
-    def test_local_blocked_params(self) -> None:
+    def test_local_blocked_params(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_local_blocked_params(self)
 
     def _expected_local_block_info_list(
@@ -667,7 +668,7 @@ class HybridShardDistributorOnEmptyParamTest(
         }[dist.get_rank()]
 
     @with_comms
-    def test_local_block_info_list(self) -> None:
+    def test_local_block_info_list(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_local_block_info_list(self)
 
     @property
@@ -675,5 +676,5 @@ class HybridShardDistributorOnEmptyParamTest(
         return ()
 
     @with_comms
-    def test_merge_and_block_gradients(self) -> None:
+    def test_merge_and_block_gradients(self) -> None:  # type: ignore[override]
         DistributorOnEmptyParamTest.Interface.test_merge_and_block_gradients(self)


### PR DESCRIPTION
Summary: This diff fixes the mypy complains due to `FSDPMoudle` on `*EmptyParamsTest`s.

Differential Revision: D78830675


