### PR TITLE
Fix accidentally skipped warnings test

### DIFF
--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -396,8 +396,12 @@ class DistributedShampoo(torch.optim.Optimizer):
         if isinstance(preconditioner_config, SpectralDescentPreconditionerConfig):
             # Warn about hyperparameters that won't have any effect.
             logger.warning(
-                f"{betas[1]=} does not have any effect when SpectralDescentPreconditionerConfig is used.\n"
-                f"{epsilon=} does not have any effect when SpectralDescentPreconditionerConfig is used.\n"
+                f"{betas[1]=} does not have any effect when SpectralDescentPreconditionerConfig is used."
+            )
+            logger.warning(
+                f"{epsilon=} does not have any effect when SpectralDescentPreconditionerConfig is used."
+            )
+            logger.warning(
                 f"{precondition_frequency=} does not have any effect when SpectralDescentPreconditionerConfig is used. Setting precondition_frequency to 1..."
             )
             precondition_frequency = 1


### PR DESCRIPTION
Summary: The test for the warnings was accidentally skipped before since the command failed due to an error related to non-space white space. Also, I think using a separate warning for each line results in better readability and makes sense since they are in principle independent (might be removed one by one).

Differential Revision: D78867298


