### PR TITLE
Remove distributed_config argument to distributors

### DIFF
--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -396,8 +396,12 @@ class DistributedShampoo(torch.optim.Optimizer):
         if isinstance(preconditioner_config, SpectralDescentPreconditionerConfig):
             # Warn about hyperparameters that won't have any effect.
             logger.warning(
-                f"{betas[1]=} does not have any effect when SpectralDescentPreconditionerConfig is used.\n"
-                f"{epsilon=} does not have any effect when SpectralDescentPreconditionerConfig is used.\n"
+                f"{betas[1]=} does not have any effect when SpectralDescentPreconditionerConfig is used."
+            )
+            logger.warning(
+                f"{epsilon=} does not have any effect when SpectralDescentPreconditionerConfig is used."
+            )
+            logger.warning(
                 f"{precondition_frequency=} does not have any effect when SpectralDescentPreconditionerConfig is used. Setting precondition_frequency to 1..."
             )
             precondition_frequency = 1

--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -497,24 +497,15 @@ class DistributedShampoo(torch.optim.Optimizer):
         ):
             match group[DISTRIBUTED_CONFIG]:
                 case None:
-                    distributor_cls: Callable[..., DistributorInterface] = Distributor
+                    distributor_cls: type[DistributorInterface] = Distributor
                 case HSDPShampooConfig():
-                    distributor_cls = partial(
-                        HSDPDistributor, distributed_config=group[DISTRIBUTED_CONFIG]
-                    )
+                    distributor_cls = HSDPDistributor
                 case HybridShardShampooConfig():
-                    distributor_cls = partial(
-                        HybridShardDistributor,
-                        distributed_config=group[DISTRIBUTED_CONFIG],
-                    )
+                    distributor_cls = HybridShardDistributor
                 case DDPShampooConfig():
-                    distributor_cls = partial(
-                        DDPDistributor, distributed_config=group[DISTRIBUTED_CONFIG]
-                    )
+                    distributor_cls = DDPDistributor
                 case FSDPShampooConfig():
-                    distributor_cls = partial(
-                        FSDPDistributor, distributed_config=group[DISTRIBUTED_CONFIG]
-                    )
+                    distributor_cls = FSDPDistributor
                 case FullyShardShampooConfig():
                     distributor_cls = FullyShardDistributor
                 case _:

--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -716,7 +716,6 @@ class AbstractTest:
                     max_preconditioner_dim=PRECONDITIONER_DIM,
                     distributed_config=distributed_config,
                 ).param_groups[0],
-                distributed_config=distributed_config,
             )
 
             # Get the weight of the linear layers (which is empty) and set its gradient

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
@@ -273,7 +273,6 @@ class FSDPDistributorOnEmptyParamTest(FSDPTest, DistributorOnEmptyParamTest.Inte
                 max_preconditioner_dim=PRECONDITIONER_DIM,
                 distributed_config=distributed_config,
             ).param_groups[0],
-            distributed_config=distributed_config,
         )
 
         # Get the weight of the linear layers (which is empty) and set its gradient

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -385,7 +385,6 @@ class HSDPDistributorOnEmptyParamTest(FSDPTest, DistributorOnEmptyParamTest.Inte
                 max_preconditioner_dim=PRECONDITIONER_DIM,
                 distributed_config=distributed_config,
             ).param_groups[0],
-            distributed_config=distributed_config,
         )
 
         # Get the weight of the linear layers (which is empty) and set its gradient

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
@@ -558,7 +558,6 @@ class HybridShardDistributorOnEmptyParamTest(
                 max_preconditioner_dim=PRECONDITIONER_DIM,
                 distributed_config=distributed_config,
             ).param_groups[0],
-            distributed_config=distributed_config,
         )
 
         # Get the weight of the linear layers (which is empty) and set its gradient

--- a/distributed_shampoo/utils/shampoo_distributor.py
+++ b/distributed_shampoo/utils/shampoo_distributor.py
@@ -289,12 +289,10 @@ class Distributor(DistributorInterface):
 
     Args:
         param_group (dict[str, Any]): Parameter group containing parameters.
+
     """
 
-    def __init__(
-        self,
-        param_group: dict[str, Any],
-    ) -> None:
+    def __init__(self, param_group: dict[str, Any]) -> None:
         super().__init__(param_group)
 
         # Initialize selectors and local blocked (masked) parameters.

--- a/distributed_shampoo/utils/shampoo_fsdp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_fsdp_distributor.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import torch
 from distributed_shampoo.shampoo_types import (
+    DISTRIBUTED_CONFIG,
     FSDPParameterMetadata,
     FSDPShampooConfig,
     MAX_PRECONDITIONER_DIM,
@@ -39,15 +40,11 @@ class FSDPDistributor(Distributor):
 
     Args:
         param_group (dict[str, Any]): Parameter group containing parameters.
-        distributed_config (FSDPShampooConfig): Configuration for FSDP Shampoo.
 
     """
 
-    def __init__(
-        self,
-        param_group: dict[str, Any],
-        distributed_config: FSDPShampooConfig,
-    ) -> None:
+    def __init__(self, param_group: dict[str, Any]) -> None:
+        distributed_config: FSDPShampooConfig = param_group[DISTRIBUTED_CONFIG]
         self._param_to_metadata: dict[Parameter, FSDPParameterMetadata] = (
             distributed_config.param_to_metadata
         )

--- a/distributed_shampoo/utils/shampoo_hsdp_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hsdp_distributor.py
@@ -16,6 +16,7 @@ from typing import Any
 import torch
 from commons import batched
 from distributed_shampoo.shampoo_types import (
+    DISTRIBUTED_CONFIG,
     FSDPParameterMetadata,
     HSDPShampooConfig,
     MAX_PRECONDITIONER_DIM,
@@ -86,15 +87,11 @@ class HSDPDistributor(DistributorInterface):
 
     Args:
         param_group (dict[str, Any]): Parameter group containing parameters.
-        distributed_config (HSDPShampooConfig): Configuration for HSDP Shampoo.
 
     """
 
-    def __init__(
-        self,
-        param_group: dict[str, Any],
-        distributed_config: HSDPShampooConfig,
-    ) -> None:
+    def __init__(self, param_group: dict[str, Any]) -> None:
+        distributed_config: HSDPShampooConfig = param_group[DISTRIBUTED_CONFIG]
         self._param_to_metadata: dict[Parameter, FSDPParameterMetadata] = (
             distributed_config.param_to_metadata
         )

--- a/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
+++ b/distributed_shampoo/utils/shampoo_hybrid_shard_distributor.py
@@ -15,7 +15,11 @@ from typing import Any, Literal, overload
 
 import torch
 from commons import batched
-from distributed_shampoo.shampoo_types import HybridShardShampooConfig, PARAMS
+from distributed_shampoo.shampoo_types import (
+    DISTRIBUTED_CONFIG,
+    HybridShardShampooConfig,
+    PARAMS,
+)
 from distributed_shampoo.utils.shampoo_block_info import DTensorBlockInfo
 from distributed_shampoo.utils.shampoo_dist_utils import get_device_mesh
 from distributed_shampoo.utils.shampoo_distributor import DistributorInterface
@@ -74,15 +78,11 @@ class HybridShardDistributor(DistributorInterface):
 
     Args:
         param_group (dict[str, Any]): Parameter group containing parameters.
-        distributed_config (HybridShardShampooConfig): Configuration for HybridShard Shampoo.
 
     """
 
-    def __init__(
-        self,
-        param_group: dict[str, Any],
-        distributed_config: HybridShardShampooConfig,
-    ) -> None:
+    def __init__(self, param_group: dict[str, Any]) -> None:
+        distributed_config: HybridShardShampooConfig = param_group[DISTRIBUTED_CONFIG]
         self._hybrid_shard_device_mesh: torch.distributed.device_mesh.DeviceMesh = (
             distributed_config.device_mesh
         )


### PR DESCRIPTION
Summary: Since we now allow per-parameter group `distributed_config`s, there is no reason to explicitly pass them to the distributor classes.

Differential Revision: D78867296


