### PR TITLE
Only call `sampler.set_epoch()` on `DistributedSampler`

### DIFF
--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -665,7 +665,8 @@ def train_model(
     # main training loop
     for epoch in range(epochs):
         metrics._epoch = epoch
-        sampler.set_epoch(epoch)  # type: ignore[attr-defined]
+        if isinstance(sampler, torch.utils.data.distributed.DistributedSampler):
+            sampler.set_epoch(epoch)
 
         for inputs, labels in data_loader:
             inputs, labels = inputs.to(device), labels.to(device)


### PR DESCRIPTION
Summary: Becase only [`torch.utils.data.distributed.DistributedSampler` needs to use `set_epoch()`](https://docs.pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler), this diff addresses this issue to prevent mypy complain.

Differential Revision: D79115493


