### PR TITLE
Refactor `BaseShampooPreconditionerList._amortized_computation()`

### DIFF
--- a/distributed_shampoo/utils/dict_zip_iterator.py
+++ b/distributed_shampoo/utils/dict_zip_iterator.py
@@ -1,0 +1,109 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+"""
+
+from collections.abc import Iterator
+from typing import Generic, TypeVar
+
+_DictValType = TypeVar("_DictValType")
+
+
+class DictZipIterator(Generic[_DictValType], Iterator[dict[str, _DictValType]]):
+    """
+    Iterator that yields dictionaries by zipping values from iterators in a dictionary.
+
+    Given a dictionary mapping from strings to iterators,
+    each iteration yields a new dictionary with the same keys but with values
+    taken from the corresponding position in each iterator.
+
+    All iterators must have the same length. If iterators have different lengths,
+    a ValueError will be raised when the length mismatch is detected.
+
+    Example:
+        # Same length iterators - works correctly
+        data = {
+            "a": iter([1, 2, 3]),
+            "b": iter(["x", "y", "z"]),
+            "c": iter([True, False, True])
+        }
+
+        iterator = DictZipIterator(data)
+
+        # First iteration: {"a": 1, "b": "x", "c": True}
+        # Second iteration: {"a": 2, "b": "y", "c": False}
+        # Third iteration: {"a": 3, "b": "z", "c": True}
+        # StopIteration is raised after all iterators are exhausted
+
+        # Different length iterators - raises ValueError
+        data_mismatched = {
+            "a": iter([1, 2, 3]),
+            "b": iter(["x", "y"]),  # Shorter iterator
+        }
+
+        iterator = DictZipIterator(data_mismatched)
+        next(iterator)  # {"a": 1, "b": "x"}
+        next(iterator)  # {"a": 2, "b": "y"}
+        next(iterator)  # Raises ValueError: Iterators have different lengths
+    """
+
+    def __init__(self, data: dict[str, Iterator[_DictValType]]) -> None:
+        """
+        Initialize the iterator with a dictionary mapping from strings to iterators.
+
+        Args:
+            data: Dictionary mapping from strings to iterators
+
+        Returns:
+            None
+        """
+        self._keys: tuple[str, ...] = tuple(data.keys())
+        # Create an iterator for each iterable in the dictionary
+        self._iterators: dict[str, Iterator[_DictValType]] = {
+            key: iter(value) for key, value in data.items()
+        }
+
+    def __iter__(self) -> Iterator[dict[str, _DictValType]]:
+        """Return self as iterator."""
+        return self
+
+    def __next__(self) -> dict[str, _DictValType]:
+        """
+        Return the next dictionary with values from the current position.
+
+        Returns:
+            Dictionary with the same keys as the input dictionary, but with values
+            from the current position in each iterable
+
+        Raises:
+            StopIteration: When all iterables are exhausted at the same time
+            ValueError: When iterables have different lengths (some exhausted while others have values)
+        """
+        result = {}
+        exhausted_keys = []
+        active_keys = []
+
+        # Try to get next value from each iterator
+        for key in self._keys:
+            try:
+                result[key] = next(self._iterators[key])
+                active_keys.append(key)
+            except StopIteration:
+                exhausted_keys.append(key)
+
+        # If some iterators are exhausted but not all, raise an error
+        if exhausted_keys and active_keys:
+            raise ValueError(
+                f"Iterators have different lengths. "
+                f"Exhausted: {exhausted_keys}, Still active: {active_keys}"
+            )
+
+        # If all iterators are exhausted, stop iteration
+        if exhausted_keys:
+            raise StopIteration
+
+        return result

--- a/distributed_shampoo/utils/tests/dict_zip_iterator_test.py
+++ b/distributed_shampoo/utils/tests/dict_zip_iterator_test.py
@@ -1,0 +1,105 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+"""
+
+import unittest
+from collections.abc import Iterator
+
+from distributed_shampoo.utils.dict_zip_iterator import DictZipIterator
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+
+@instantiate_parametrized_tests
+class DictZipIteratorTest(unittest.TestCase):
+    @parametrize(
+        "data, expected_results",
+        (
+            (
+                {
+                    "a": [1, 2, 3],
+                    "b": ["x", "y", "z"],
+                    "c": [True, False, True],
+                },
+                [
+                    {"a": 1, "b": "x", "c": True},
+                    {"a": 2, "b": "y", "c": False},
+                    {"a": 3, "b": "z", "c": True},
+                ],
+            ),
+        ),
+    )
+    def test_dict_zip_iterator_same_length(
+        self,
+        data: dict[str, Iterator[object]],
+        expected_results: list[dict[str, object]],
+    ) -> None:
+        iterator = DictZipIterator(data=data)
+
+        self.assertEqual(expected_results, list(iterator))
+
+        # Test StopIteration when all iterators are exhausted
+        with self.assertRaises(StopIteration):
+            next(iterator)
+
+    def test_dict_zip_iterator_different_lengths_raises_error(self) -> None:
+        """Test that ValueError is raised when iterators have different lengths."""
+        data = {
+            "a": iter([1, 2, 3]),
+            "b": iter(["x", "y", "z"]),
+            "c": iter([True, False]),  # Shorter list
+        }
+        iterator = DictZipIterator(data=data)
+
+        # First iteration should work
+        result1 = next(iterator)
+        self.assertEqual(result1, {"a": 1, "b": "x", "c": True})
+
+        # Second iteration should work
+        result2 = next(iterator)
+        self.assertEqual(result2, {"a": 2, "b": "y", "c": False})
+
+        # Third iteration should raise ValueError because 'c' is exhausted but 'a' and 'b' still have values
+        with self.assertRaises(ValueError) as context:
+            next(iterator)
+
+        error_message = str(context.exception)
+        self.assertIn("Iterators have different lengths", error_message)
+        self.assertIn("Exhausted: ['c']", error_message)
+        self.assertIn("Still active: ['a', 'b']", error_message)
+
+    def test_dict_zip_iterator_empty_iterators(self) -> None:
+        """Test that empty iterators raise StopIteration immediately."""
+        data: dict[str, Iterator[object]] = {
+            "a": iter([]),
+            "b": iter([]),
+        }
+        iterator = DictZipIterator(data=data)
+
+        # Should raise StopIteration immediately
+        with self.assertRaises(StopIteration):
+            next(iterator)
+
+    def test_dict_zip_iterator_single_element(self) -> None:
+        """Test with single element iterators."""
+        data = {
+            "a": iter([1]),
+            "b": iter(["x"]),
+            "c": iter([True]),
+        }
+        iterator = DictZipIterator(data=data)
+
+        # First iteration should work
+        result = next(iterator)
+        self.assertEqual(result, {"a": 1, "b": "x", "c": True})
+
+        # Second iteration should raise StopIteration
+        with self.assertRaises(StopIteration):
+            next(iterator)

--- a/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
+++ b/distributed_shampoo/utils/tests/shampoo_preconditioner_list_test.py
@@ -914,10 +914,9 @@ class AbstractTest:
                     step += 1
                 # Exactly at failure tolerance now.
                 with self.assertLogs(level="WARNING") as cm:
-                    expected_error_message = r"The number of failed .* for factors \('0.block_0.0',\) exceeded the allowed tolerance\."
                     self.assertRaisesRegex(
                         ValueError,
-                        expected_error_message,
+                        r"The number of failed amortized computations for factors \('0\.block_0\.0',\) exceeded the allowed tolerance\. The last seen exception was .*",
                         self._preconditioner_list.update_preconditioners,
                         masked_grad_list=masked_grad_list,
                         step=torch.tensor(step),
@@ -1014,7 +1013,7 @@ class AbstractTest:
 
         @property
         def _expected_compress_list_call_count(self) -> int:
-            return 4
+            return 3
 
     class ClassicShampooPreconditionerListTest(BaseShampooPreconditionerListTest):
         @property


### PR DESCRIPTION
Summary:
This diff refactors the `amortized_computation()` into each `ShampooKroneckerFactorsUnwrapped`.

To achieve this:
1. Introduce `DictZipIterator` to enables iterating each fields in a zip fashion of different `*ShampooKroneckerFactorsUnwrapped` dataclasses.
2. This enables the push of the common parts of `*ShampooPreconditionerList._amortized_computation()` previously to `*ShampooKroneckerFactorsUnwrapped.update_preconditioners()`.

Differential Revision: D77490283
