### PR TITLE
Remove redundant `logging` usages

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -10,7 +10,6 @@ LICENSE file in the root directory of this source tree.
 #!/usr/bin/env python3
 
 import argparse
-import logging
 import os
 from functools import partial
 from typing import Any
@@ -32,12 +31,6 @@ from distributed_shampoo.examples.trainer_utils import (
 )
 from torch import nn
 from torchvision.datasets import VisionDataset
-
-logging.basicConfig(
-    format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
-    level=logging.DEBUG,
-)
-logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -10,7 +10,6 @@ LICENSE file in the root directory of this source tree.
 #!/usr/bin/env python3
 
 import argparse
-import logging
 import os
 
 import torch
@@ -25,12 +24,6 @@ from distributed_shampoo.examples.trainer_utils import (
 )
 from torch import nn
 from torchvision.datasets import VisionDataset
-
-logging.basicConfig(
-    format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
-    level=logging.DEBUG,
-)
-logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

--- a/distributed_shampoo/examples/fsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/fsdp_cifar10_example.py
@@ -10,7 +10,6 @@ LICENSE file in the root directory of this source tree.
 #!/usr/bin/env python3
 
 import argparse
-import logging
 import os
 from functools import partial
 
@@ -31,12 +30,6 @@ from distributed_shampoo.examples.trainer_utils import (
 from torch import nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torchvision.datasets import VisionDataset
-
-logging.basicConfig(
-    format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
-    level=logging.DEBUG,
-)
-logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

--- a/distributed_shampoo/examples/fully_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/fully_shard_cifar10_example.py
@@ -10,7 +10,6 @@ LICENSE file in the root directory of this source tree.
 #!/usr/bin/env python3
 
 import argparse
-import logging
 import os
 
 import torch
@@ -31,12 +30,6 @@ from torch import nn
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed.fsdp import FSDPModule
 from torchvision.datasets import VisionDataset
-
-logging.basicConfig(
-    format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
-    level=logging.DEBUG,
-)
-logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

--- a/distributed_shampoo/examples/hsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/hsdp_cifar10_example.py
@@ -10,7 +10,6 @@ LICENSE file in the root directory of this source tree.
 #!/usr/bin/env python3
 
 import argparse
-import logging
 import os
 from functools import partial
 
@@ -33,12 +32,6 @@ from torch import nn
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
 from torchvision.datasets import VisionDataset
-
-logging.basicConfig(
-    format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
-    level=logging.DEBUG,
-)
-logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

--- a/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
@@ -10,7 +10,6 @@ LICENSE file in the root directory of this source tree.
 #!/usr/bin/env python3
 
 import argparse
-import logging
 import os
 from functools import partial
 
@@ -33,12 +32,6 @@ from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.fsdp import FSDPModule
 from torchvision.datasets import VisionDataset
-
-logging.basicConfig(
-    format="[%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
-    level=logging.DEBUG,
-)
-logger: logging.Logger = logging.getLogger(__name__)
 
 # for reproducibility, set environmental variable for CUBLAS
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

--- a/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_ddp_distributor_test.py
@@ -567,7 +567,7 @@ class AbstractTest:
             self._init_distributed()
 
             steps_without_gradients = 2
-            with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+            with unittest.mock.patch.object(torch.Tensor, "backward") as mock_backward:
                 # By mocking the backward() method, we're intercepting gradient calculation.
                 # This effectively simulates running forward passes without computing gradients.
                 train_model(

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fsdp_distributor_test.py
@@ -129,7 +129,7 @@ class ShampooFSDPDistributorTest(FSDPTest):
         fsdp_config = FSDPShampooConfig(param_to_metadata={})
 
         steps_without_gradients = 2
-        with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+        with unittest.mock.patch.object(torch.Tensor, "backward") as mock_backward:
             # By mocking the backward() method, we're intercepting gradient calculation.
             # This effectively simulates running forward passes without computing gradients.
             train_model(

--- a/distributed_shampoo/utils/gpu_tests/shampoo_fully_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_fully_shard_distributor_test.py
@@ -136,7 +136,7 @@ class ShampooFullyShardDistributorTest(DTensorTestBase):
         fully_shard_config = FullyShardShampooConfig()  # type: ignore[abstract]
 
         steps_without_gradients = 2
-        with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+        with unittest.mock.patch.object(torch.Tensor, "backward") as mock_backward:
             # By mocking the backward() method, we're intercepting gradient calculation.
             # This effectively simulates running forward passes without computing gradients.
             train_model(

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hsdp_distributor_test.py
@@ -228,7 +228,7 @@ class ShampooHSDPDistributorTest(FSDPTest):
         )
 
         steps_without_gradients = 2
-        with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+        with unittest.mock.patch.object(torch.Tensor, "backward") as mock_backward:
             # By mocking the backward() method, we're intercepting gradient calculation.
             # This effectively simulates running forward passes without computing gradients.
             train_model(

--- a/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
+++ b/distributed_shampoo/utils/gpu_tests/shampoo_hybrid_shard_distributor_test.py
@@ -361,7 +361,7 @@ class ShampooHybridShardDistributorTest(DTensorTestBase):
         )
 
         steps_without_gradients = 2
-        with unittest.mock.patch("torch.Tensor.backward") as mock_backward:
+        with unittest.mock.patch.object(torch.Tensor, "backward") as mock_backward:
             # By mocking the backward() method, we're intercepting gradient calculation.
             # This effectively simulates running forward passes without computing gradients.
             train_model(


### PR DESCRIPTION
Summary: We did not use any of those `logger`s at all; as a result, this diff removes those usages.

Differential Revision: D79151061


