### PR TITLE
Fix examples due to the removal of `preconditioner_dtype`

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -131,7 +131,6 @@ if __name__ == "__main__":
             num_trainers_per_group=args.num_trainers_per_group,
             communicate_params=args.communicate_params,
         ),
-        preconditioner_dtype=args.preconditioner_dtype,
         preconditioner_computation_type=args.preconditioner_computation_type,
     )
 

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -136,7 +136,6 @@ if __name__ == "__main__":
         grafting_beta2=args.grafting_beta2,
         use_merge_dims=args.use_merge_dims,
         distributed_config=None,
-        preconditioner_dtype=args.preconditioner_dtype,
         preconditioner_computation_type=args.preconditioner_computation_type,
     )
 

--- a/distributed_shampoo/examples/fsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/fsdp_cifar10_example.py
@@ -121,7 +121,6 @@ if __name__ == "__main__":
         distributed_config=FSDPShampooConfig(
             param_to_metadata=compile_fsdp_parameter_metadata(model),
         ),
-        preconditioner_dtype=args.preconditioner_dtype,
         preconditioner_computation_type=args.preconditioner_computation_type,
     )
 

--- a/distributed_shampoo/examples/fully_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/fully_shard_cifar10_example.py
@@ -72,7 +72,6 @@ def create_model_and_optimizer_and_loss_fn(
         grafting_beta2=args.grafting_beta2,
         use_merge_dims=args.use_merge_dims,
         distributed_config=FullyShardShampooConfig(),  # type: ignore[abstract]
-        preconditioner_dtype=args.preconditioner_dtype,
         preconditioner_computation_type=args.preconditioner_computation_type,
     )
     return model, optimizer, loss_function

--- a/distributed_shampoo/examples/hsdp_cifar10_example.py
+++ b/distributed_shampoo/examples/hsdp_cifar10_example.py
@@ -138,7 +138,6 @@ if __name__ == "__main__":
             device_mesh=device_mesh,
             num_trainers_per_group=args.num_trainers_per_group,
         ),
-        preconditioner_dtype=args.preconditioner_dtype,
         preconditioner_computation_type=args.preconditioner_computation_type,
     )
 

--- a/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/hybrid_shard_cifar10_example.py
@@ -78,7 +78,6 @@ def create_model_and_optimizer_and_loss_fn(
             device_mesh=device_mesh,
             num_trainers_per_group=args.num_trainers_per_group,
         ),
-        preconditioner_dtype=args.preconditioner_dtype,
         preconditioner_computation_type=args.preconditioner_computation_type,
     )
     return model, optimizer, loss_function

--- a/distributed_shampoo/examples/trainer_utils.py
+++ b/distributed_shampoo/examples/trainer_utils.py
@@ -230,14 +230,6 @@ class Parser:
             help="Grafting beta2 parameter for Shampoo.",
         )
 
-        # Arguments for mixed-precision.
-        parser.add_argument(
-            "--preconditioner-dtype",
-            type=lambda t: attrgetter(t)(torch),
-            default=torch.float32,
-            help="Preconditioner dtype for Shampoo.",
-        )
-
         # Arguments for DDP Shampoo.
         parser.add_argument(
             "--communication-dtype",
@@ -407,7 +399,6 @@ def instantiate_optimizer(
     grafting_epsilon: float,
     use_merge_dims: bool,
     distributed_config: DistributedConfig | None,
-    preconditioner_dtype: torch.dtype,
     preconditioner_computation_type: PreconditionerComputationType,
 ) -> torch.optim.Optimizer:
     if optimizer_type == OptimizerType.SGD:
@@ -445,7 +436,6 @@ def instantiate_optimizer(
             ),
             use_merge_dims=use_merge_dims,
             distributed_config=distributed_config,
-            preconditioner_dtype=preconditioner_dtype,
             preconditioner_config=instantiate_preconditioner_config(
                 preconditioner_computation_type=preconditioner_computation_type,
                 exponent_multiplier=exponent_multiplier,


### PR DESCRIPTION
Summary: This diff fixes the incorrect references to `preconditioner_dtype` due to https://github.com/facebookresearch/optimizers/commit/0602074762b359bba18f383f63b2c38f8cdd28b9. `preconditioner_dtype` is now handled by `PreconditionerConfig.factor_matrix_dtype`.

Differential Revision: D79204539


