### PR TITLE
Fix mypy complain on `ddp_cifar10_example.py`

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
                 device_ids=[LOCAL_RANK],
                 output_device=LOCAL_RANK,
             ),
-            "gloo": nn.parallel.DistributedDataParallel,
+            "gloo": partial(nn.parallel.DistributedDataParallel),
         }[args.backend],
     )
 


### PR DESCRIPTION
Summary: The diff fixes the `post_model_decoration` input argument so mypy won't complain.

Differential Revision: D52525874


