### PR TITLE
Make hyperparameter check consistent

### DIFF
--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -360,22 +360,20 @@ class DistributedShampoo(torch.optim.Optimizer):
 
         def param_group_hyperparameter_check(param_group: dict[str, Any]) -> None:
             if not param_group[LR] >= 0.0:
-                raise ValueError(
-                    f"Invalid learning rate: {param_group[LR]}. Must be >= 0.0."
-                )
+                raise ValueError(f"Invalid {param_group[LR]=}. Must be >= 0.0.")
             if not 0.0 <= param_group[BETAS][0] < 1.0:
                 raise ValueError(
-                    f"Invalid beta parameter at index 0: {param_group[BETAS][0]}. Must be in [0.0, 1.0)."
+                    f"Invalid {param_group[BETAS][0]=}. Must be in [0.0, 1.0)."
                 )
             if not 0.0 <= param_group[BETAS][1] <= 1.0:
                 raise ValueError(
-                    f"Invalid beta parameter at index 1: {param_group[BETAS][1]}. Must be in [0.0, 1.0]."
+                    f"Invalid {param_group[BETAS][1]=}. Must be in [0.0, 1.0]."
                 )
             if param_group[BETA3] == -1.0:
                 param_group[BETA3] = param_group[BETAS][0]
             elif not 0.0 <= param_group[BETA3] < 1.0:
                 raise ValueError(
-                    f"Invalid beta3 parameter: {param_group[BETA3]}. Must be in [0.0, 1.0)."
+                    f"Invalid {param_group[BETA3]=}. Must be in [0.0, 1.0)."
                 )
             if (
                 isinstance(
@@ -395,42 +393,40 @@ class DistributedShampoo(torch.optim.Optimizer):
             ):
                 if param_group[EPSILON] != 0.0:
                     raise ValueError(
-                        f"Invalid epsilon value: {param_group[EPSILON]}. Must be == 0.0 when PseudoInverseConfig is used."
+                        f"Invalid {param_group[EPSILON]=}. Must be == 0.0 when PseudoInverseConfig is used."
                     )
             elif not param_group[EPSILON] > 0.0:
-                raise ValueError(
-                    f"Invalid epsilon value: {param_group[EPSILON]}. Must be > 0.0."
-                )
+                raise ValueError(f"Invalid {param_group[EPSILON]=}. Must be > 0.0.")
             if not 0.0 <= param_group[MOMENTUM] < 1.0:
                 raise ValueError(
-                    f"Invalid momentum parameter: {param_group[MOMENTUM]}. Must be [0.0, 1.0)."
+                    f"Invalid {param_group[MOMENTUM]=}. Must be [0.0, 1.0)."
                 )
             if not 0.0 <= param_group[DAMPENING] < 1.0:
                 raise ValueError(
-                    f"Invalid damping parameter: {param_group[DAMPENING]}. Must be [0.0, 1.0)."
+                    f"Invalid {param_group[DAMPENING]=}. Must be [0.0, 1.0)."
                 )
             if not param_group[WEIGHT_DECAY] >= 0.0:
                 raise ValueError(
-                    f"Invalid weight_decay value: {param_group[WEIGHT_DECAY]}. Must be >= 0.0."
+                    f"Invalid {param_group[WEIGHT_DECAY]=}. Must be >= 0.0."
                 )
             if (
                 isinstance(param_group[MAX_PRECONDITIONER_DIM], float)
                 and param_group[MAX_PRECONDITIONER_DIM] != math.inf
             ):
                 raise ValueError(
-                    f"Invalid {param_group[MAX_PRECONDITIONER_DIM]=} value. Must be an integer or math.inf."
+                    f"Invalid {param_group[MAX_PRECONDITIONER_DIM]=}. Must be an integer or math.inf."
                 )
             if not param_group[MAX_PRECONDITIONER_DIM] >= 1:
                 raise ValueError(
-                    f"Invalid max preconditioner dimension: {param_group[MAX_PRECONDITIONER_DIM]}. Must be >= 1."
+                    f"Invalid {param_group[MAX_PRECONDITIONER_DIM]=}. Must be >= 1."
                 )
             if not param_group[PRECONDITION_FREQUENCY] >= 1:
                 raise ValueError(
-                    f"Invalid precondition frequency: {param_group[PRECONDITION_FREQUENCY]}. Must be >= 1."
+                    f"Invalid {param_group[PRECONDITION_FREQUENCY]=}. Must be >= 1."
                 )
             if not param_group[START_PRECONDITIONING_STEP] >= -1:
                 raise ValueError(
-                    f"Invalid start preconditioning step: {param_group[START_PRECONDITIONING_STEP]}. Must be >= -1."
+                    f"Invalid {param_group[START_PRECONDITIONING_STEP]=}. Must be >= -1."
                 )
 
             if isinstance(
@@ -477,14 +473,13 @@ class DistributedShampoo(torch.optim.Optimizer):
                 < param_group[PRECONDITION_FREQUENCY]
             ):
                 raise ValueError(
-                    f"Invalid start_preconditioning_step value: {param_group[START_PRECONDITIONING_STEP]}. Must be >= {param_group[PRECONDITION_FREQUENCY]=}."
+                    f"Invalid {param_group[START_PRECONDITIONING_STEP]=}. Must be >= {param_group[PRECONDITION_FREQUENCY]=}."
                 )
 
             # Warn when Nesterov is used but momentum is 0.
             if param_group[USE_NESTEROV] and param_group[MOMENTUM] == 0.0:
                 logger.warning(
-                    "Nesterov flag is enabled but momentum parameter is zero! "
-                    "Continuing without using momentum or Nesterov acceleration..."
+                    "Nesterov flag is enabled but momentum parameter is zero! Continuing without using momentum or Nesterov acceleration..."
                 )
 
         # Perform per param_group hyperparameter checks.

--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -93,23 +93,19 @@ class DistributedShampooInitTest(unittest.TestCase):
         [
             (
                 {"lr": -0.1},
-                "Invalid learning rate: -0.1. Must be >= 0.0.",
+                "Invalid param_group[LR]=-0.1. Must be >= 0.0.",
             ),
             (
                 {"betas": (-0.1, 1.0)},
-                "Invalid beta parameter at index 0: -0.1. Must be in [0.0, 1.0).",
+                "Invalid param_group[BETAS][0]=-0.1. Must be in [0.0, 1.0).",
             ),
             (
                 {"betas": (0.9, -0.1)},
-                "Invalid beta parameter at index 1: -0.1. Must be in [0.0, 1.0].",
+                "Invalid param_group[BETAS][1]=-0.1. Must be in [0.0, 1.0].",
             ),
             (
                 {"beta3": -0.1},
-                "Invalid beta3 parameter: -0.1. Must be in [0.0, 1.0).",
-            ),
-            (
-                {"epsilon": 0.0},
-                "Invalid epsilon value: 0.0. Must be > 0.0.",
+                "Invalid param_group[BETA3]=-0.1. Must be in [0.0, 1.0).",
             ),
             (
                 {
@@ -120,39 +116,43 @@ class DistributedShampooInitTest(unittest.TestCase):
                         )
                     ),
                 },
-                "Invalid epsilon value: 0.1. Must be == 0.0 when PseudoInverseConfig is used.",
+                "Invalid param_group[EPSILON]=0.1. Must be == 0.0 when PseudoInverseConfig is used.",
+            ),
+            (
+                {"epsilon": 0.0},
+                "Invalid param_group[EPSILON]=0.0. Must be > 0.0.",
             ),
             (
                 {"momentum": 3.14},
-                "Invalid momentum parameter: 3.14. Must be [0.0, 1.0).",
+                "Invalid param_group[MOMENTUM]=3.14. Must be [0.0, 1.0).",
             ),
             (
                 {"dampening": -0.1},
-                "Invalid damping parameter: -0.1. Must be [0.0, 1.0).",
+                "Invalid param_group[DAMPENING]=-0.1. Must be [0.0, 1.0).",
             ),
             (
                 {"weight_decay": -0.1},
-                "Invalid weight_decay value: -0.1. Must be >= 0.0.",
+                "Invalid param_group[WEIGHT_DECAY]=-0.1. Must be >= 0.0.",
             ),
             (
                 {"max_preconditioner_dim": 3.14},
-                "Invalid param_group[MAX_PRECONDITIONER_DIM]=3.14 value. Must be an integer or math.inf.",
+                "Invalid param_group[MAX_PRECONDITIONER_DIM]=3.14. Must be an integer or math.inf.",
             ),
             (
                 {"max_preconditioner_dim": 0},
-                "Invalid max preconditioner dimension: 0. Must be >= 1.",
+                "Invalid param_group[MAX_PRECONDITIONER_DIM]=0. Must be >= 1.",
             ),
             (
                 {"precondition_frequency": 0},
-                "Invalid precondition frequency: 0. Must be >= 1.",
+                "Invalid param_group[PRECONDITION_FREQUENCY]=0. Must be >= 1.",
             ),
             (
                 {"start_preconditioning_step": -2},
-                "Invalid start preconditioning step: -2. Must be >= -1.",
+                "Invalid param_group[START_PRECONDITIONING_STEP]=-2. Must be >= -1.",
             ),
             (
                 {"start_preconditioning_step": 10, "precondition_frequency": 100},
-                "Invalid start_preconditioning_step value: 10. Must be >= param_group[PRECONDITION_FREQUENCY]=100.",
+                "Invalid param_group[START_PRECONDITIONING_STEP]=10. Must be >= param_group[PRECONDITION_FREQUENCY]=100.",
             ),
         ],
     )


### PR DESCRIPTION
Summary: Unified those as f-string format always to reduce boilerplate codes, and provides implicit meaning on those errors happened at per `param_group` level.

Differential Revision: D67844337


