### PR TITLE
Factor out `create_model_and_optimizer_and_loss_fn()` in `examples/trainer_utils.py`

### DIFF
--- a/distributed_shampoo/examples/ddp_cifar10_example.py
+++ b/distributed_shampoo/examples/ddp_cifar10_example.py
@@ -21,9 +21,8 @@ import torch.distributed.checkpoint as dist_checkpoint
 
 from distributed_shampoo import DDPShampooConfig, DistributedShampoo
 from distributed_shampoo.examples.trainer_utils import (
+    create_model_and_optimizer_and_loss_fn,
     get_data_loader_and_sampler,
-    get_model_and_loss_fn,
-    instantiate_optimizer,
     Parser,
     set_seed,
     setup_distribution,
@@ -83,9 +82,16 @@ if __name__ == "__main__":
 
     # instantiate model and loss function
     model: nn.Module
+    optimizer: torch.optim.Optimizer
     loss_function: nn.Module
-    model, loss_function = get_model_and_loss_fn(
+    model, optimizer, loss_function = create_model_and_optimizer_and_loss_fn(
+        args=args,
         device=device,
+        distributed_config=DDPShampooConfig(
+            communication_dtype=args.communication_dtype,
+            num_trainers_per_group=args.num_trainers_per_group,
+            communicate_params=args.communicate_params,
+        ),
         post_model_decoration={
             "nccl": partial(
                 nn.parallel.DistributedDataParallel,
@@ -103,34 +109,6 @@ if __name__ == "__main__":
     ]
     data_loader, sampler = get_data_loader_and_sampler(
         args.data_path, WORLD_SIZE, WORLD_RANK, args.local_batch_size
-    )
-
-    # instantiate optimizer (SGD, Adam, DistributedShampoo)
-    optimizer: torch.optim.Optimizer = instantiate_optimizer(
-        args.optimizer_type,
-        model.parameters(),
-        lr=args.lr,
-        betas=(args.beta1, args.beta2),
-        beta3=args.beta3,
-        epsilon=args.epsilon,
-        momentum=args.momentum,
-        dampening=args.dampening,
-        weight_decay=args.weight_decay,
-        max_preconditioner_dim=args.max_preconditioner_dim,
-        precondition_frequency=args.precondition_frequency,
-        start_preconditioning_step=args.start_preconditioning_step,
-        use_nesterov=args.use_nesterov,
-        use_bias_correction=args.use_bias_correction,
-        use_decoupled_weight_decay=args.use_decoupled_weight_decay,
-        grafting_type=args.grafting_type,
-        grafting_beta2=args.grafting_beta2,
-        grafting_epsilon=args.grafting_epsilon,
-        distributed_config=DDPShampooConfig(
-            communication_dtype=args.communication_dtype,
-            num_trainers_per_group=args.num_trainers_per_group,
-            communicate_params=args.communicate_params,
-        ),
-        preconditioner_computation_type=args.preconditioner_computation_type,
     )
 
     # checks for checkpointing

--- a/distributed_shampoo/examples/default_cifar10_example.py
+++ b/distributed_shampoo/examples/default_cifar10_example.py
@@ -16,9 +16,8 @@ import torch
 from distributed_shampoo import DefaultSingleDeviceDistributedConfig
 
 from distributed_shampoo.examples.trainer_utils import (
+    create_model_and_optimizer_and_loss_fn,
     get_data_loader_and_sampler,
-    get_model_and_loss_fn,
-    instantiate_optimizer,
     Parser,
     set_seed,
     train_model,
@@ -66,38 +65,19 @@ if __name__ == "__main__":
 
     # instantiate model and loss function
     model: nn.Module
+    optimizer: torch.optim.Optimizer
     loss_function: nn.Module
-    model, loss_function = get_model_and_loss_fn(device=device)
+    model, optimizer, loss_function = create_model_and_optimizer_and_loss_fn(
+        args=args,
+        device=device,
+        distributed_config=DefaultSingleDeviceDistributedConfig,
+    )
 
     # instantiate data loader. Note that this is a single GPU training example,
     # so we do not need to instantiate a sampler.
     data_loader: torch.utils.data.DataLoader[VisionDataset]
     # type: ignore
     data_loader, _ = get_data_loader_and_sampler(args.data_path, 1, 0, args.batch_size)
-
-    # instantiate optimizer (SGD, Adam, DistributedShampoo)
-    optimizer: torch.optim.Optimizer = instantiate_optimizer(
-        args.optimizer_type,
-        model.parameters(),
-        lr=args.lr,
-        betas=(args.beta1, args.beta2),
-        beta3=args.beta3,
-        epsilon=args.epsilon,
-        momentum=args.momentum,
-        dampening=args.dampening,
-        weight_decay=args.weight_decay,
-        max_preconditioner_dim=args.max_preconditioner_dim,
-        precondition_frequency=args.precondition_frequency,
-        start_preconditioning_step=args.start_preconditioning_step,
-        use_nesterov=args.use_nesterov,
-        use_bias_correction=args.use_bias_correction,
-        use_decoupled_weight_decay=args.use_decoupled_weight_decay,
-        grafting_type=args.grafting_type,
-        grafting_epsilon=args.grafting_epsilon,
-        grafting_beta2=args.grafting_beta2,
-        distributed_config=DefaultSingleDeviceDistributedConfig,
-        preconditioner_computation_type=args.preconditioner_computation_type,
-    )
 
     train_model(
         model,

--- a/distributed_shampoo/examples/fully_shard_cifar10_example.py
+++ b/distributed_shampoo/examples/fully_shard_cifar10_example.py
@@ -17,9 +17,8 @@ import torch.distributed as dist
 
 from distributed_shampoo import FullyShardShampooConfig
 from distributed_shampoo.examples.trainer_utils import (
+    create_model_and_optimizer_and_loss_fn,
     get_data_loader_and_sampler,
-    get_model_and_loss_fn,
-    instantiate_optimizer,
     Parser,
     set_seed,
     setup_distribution,
@@ -38,43 +37,6 @@ os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 LOCAL_RANK = int(os.environ["LOCAL_RANK"])
 WORLD_RANK = int(os.environ["RANK"])
 WORLD_SIZE = int(os.environ["WORLD_SIZE"])
-
-
-def create_model_and_optimizer_and_loss_fn(
-    args: argparse.Namespace, device: torch.device
-) -> tuple[nn.Module, torch.optim.Optimizer, nn.Module]:
-    # instantiate model and loss function
-    model, loss_function = get_model_and_loss_fn(
-        device=device, post_model_decoration=fully_shard
-    )
-    assert isinstance(model, nn.Module)
-
-    # instantiate optimizer (SGD, Adam, DistributedShampoo)
-    optimizer = instantiate_optimizer(
-        args.optimizer_type,
-        model.parameters(),
-        lr=args.lr,
-        betas=(args.beta1, args.beta2),
-        beta3=args.beta3,
-        epsilon=args.epsilon,
-        momentum=args.momentum,
-        dampening=args.dampening,
-        weight_decay=args.weight_decay,
-        max_preconditioner_dim=args.max_preconditioner_dim,
-        precondition_frequency=args.precondition_frequency,
-        start_preconditioning_step=args.start_preconditioning_step,
-        use_nesterov=args.use_nesterov,
-        use_bias_correction=args.use_bias_correction,
-        use_decoupled_weight_decay=args.use_decoupled_weight_decay,
-        grafting_type=args.grafting_type,
-        grafting_epsilon=args.grafting_epsilon,
-        grafting_beta2=args.grafting_beta2,
-        distributed_config=FullyShardShampooConfig(
-            param_assignment_strategy=args.param_assignment_strategy
-        ),
-        preconditioner_computation_type=args.preconditioner_computation_type,
-    )
-    return model, optimizer, loss_function
 
 
 if __name__ == "__main__":
@@ -120,7 +82,14 @@ if __name__ == "__main__":
     model: nn.Module | FSDPModule
     optimizer: torch.optim.Optimizer
     loss_fn: nn.Module
-    model, optimizer, loss_fn = create_model_and_optimizer_and_loss_fn(args, device)
+    model, optimizer, loss_fn = create_model_and_optimizer_and_loss_fn(
+        args=args,
+        device=device,
+        distributed_config=FullyShardShampooConfig(
+            param_assignment_strategy=args.param_assignment_strategy
+        ),
+        post_model_decoration=fully_shard,
+    )
 
     # instantiate data loader
     data_loader: torch.utils.data.DataLoader[VisionDataset]


### PR DESCRIPTION
Summary: This diff adds `create_model_and_optimizer_and_loss_fn()` conslidates all training related examples except `fully_shard_cifar10_example.py` and `hybrid_shard_cifar10_example.py`.

Differential Revision: D68285893


