### PR TITLE
Opinionated `target_parameter_dimesntionality` when encountering `SpectralDescentConfig`

### DIFF
--- a/distributed_shampoo/distributed_shampoo.py
+++ b/distributed_shampoo/distributed_shampoo.py
@@ -452,6 +452,18 @@ class DistributedShampoo(torch.optim.Optimizer):
                 )
                 param_group[PRECONDITION_FREQUENCY] = 1
 
+            if (
+                isinstance(
+                    param_group[PRECONDITIONER_CONFIG],
+                    SpectralDescentPreconditionerConfig,
+                )
+                and param_group[DISTRIBUTED_CONFIG].target_parameter_dimensionality != 2
+            ):
+                logger.warning(
+                    f"{param_group[DISTRIBUTED_CONFIG].target_parameter_dimensionality=} is not equal to 2. Setting target_parameter_dimensionality to 2..."
+                )
+                param_group[DISTRIBUTED_CONFIG].target_parameter_dimensionality = 2
+
             # Provide warning/error for start_preconditioning_step.
             if param_group[START_PRECONDITIONING_STEP] == -1:
                 param_group[START_PRECONDITIONING_STEP] = param_group[

--- a/distributed_shampoo/tests/distributed_shampoo_test.py
+++ b/distributed_shampoo/tests/distributed_shampoo_test.py
@@ -210,15 +210,15 @@ class DistributedShampooInitTest(unittest.TestCase):
                     "epsilon": 1e-8,
                     "precondition_frequency": 100,
                     "preconditioner_config": DefaultSpectralDescentPreconditionerConfig,
-                    # distributed_config.target_parameter_dimensionality=2 is necessary to avoid reshaping parameter to 1D which prevents successful initialization of preconditioner list.
                     "distributed_config": SingleDeviceDistributedConfig(
-                        target_parameter_dimensionality=2,
+                        target_parameter_dimensionality=1,
                     ),
                 },
                 [
                     "param_group[BETAS][1]=0.999 does not have any effect when SpectralDescentPreconditionerConfig is used.",
                     "param_group[EPSILON]=1e-08 does not have any effect when SpectralDescentPreconditionerConfig is used.",
                     "param_group[PRECONDITION_FREQUENCY]=100 does not have any effect when SpectralDescentPreconditionerConfig is used. Setting precondition_frequency to 1...",
+                    "param_group[DISTRIBUTED_CONFIG].target_parameter_dimensionality=1 is not equal to 2. Setting target_parameter_dimensionality to 2...",
                 ],
             ),
             (


### PR DESCRIPTION
Summary: Based on jialun-zhang 's suggestion on setting this field to 2 always to reduce user friction on using `SpectralDescentConfig`.

Differential Revision: D61733216


