### PR TITLE
Expand more `preconditioner_config` choices in `shampoo_grafting_test.py`

### DIFF
--- a/distributed_shampoo/gpu_tests/shampoo_grafting_test.py
+++ b/distributed_shampoo/gpu_tests/shampoo_grafting_test.py
@@ -19,7 +19,10 @@ from distributed_shampoo.distributed_shampoo import DistributedShampoo
 from distributed_shampoo.shampoo_types import (
     AdaGradPreconditionerConfig,
     AdamPreconditionerConfig,
+    DefaultEigenvalueCorrectedShampooConfig,
     DefaultShampooConfig,
+    DefaultSignDescentPreconditionerConfig,
+    DefaultSOAPConfig,
     EigendecomposedShampooPreconditionerConfig,
     PreconditionerConfig,
     RMSpropPreconditionerConfig,
@@ -55,13 +58,15 @@ class DistributedShampooGraftingTest(unittest.TestCase):
         torch.device("cuda"),
     ) * torch.cuda.is_available()
 
-    @parametrize(
-        "preconditioner_config",
-        (
-            DefaultShampooConfig,
-            EigendecomposedShampooPreconditionerConfig(),
-        ),
+    preconditioner_configs: tuple[PreconditionerConfig, ...] = (
+        DefaultShampooConfig,
+        EigendecomposedShampooPreconditionerConfig(),
+        DefaultEigenvalueCorrectedShampooConfig,
+        DefaultSOAPConfig,
+        DefaultSignDescentPreconditionerConfig,
     )
+
+    @parametrize("preconditioner_config", preconditioner_configs)
     @parametrize("device", available_devices)
     @parametrize("weight_decay", (0.0, 0.3))
     def test_adagrad_grafting(
@@ -99,13 +104,7 @@ class DistributedShampooGraftingTest(unittest.TestCase):
             optim_factory=experimental_optim_factory, device=device
         )
 
-    @parametrize(
-        "preconditioner_config",
-        (
-            DefaultShampooConfig,
-            EigendecomposedShampooPreconditionerConfig(),
-        ),
-    )
+    @parametrize("preconditioner_config", preconditioner_configs)
     @parametrize("device", available_devices)
     @parametrize("weight_decay", (0.0, 0.3))
     def test_adam_grafting(
@@ -143,13 +142,7 @@ class DistributedShampooGraftingTest(unittest.TestCase):
             optim_factory=experimental_optim_factory, device=device
         )
 
-    @parametrize(
-        "preconditioner_config",
-        (
-            DefaultShampooConfig,
-            EigendecomposedShampooPreconditionerConfig(),
-        ),
-    )
+    @parametrize("preconditioner_config", preconditioner_configs)
     @parametrize("device", available_devices)
     @parametrize("weight_decay", (0.0, 0.3))
     def test_adamw_grafting(
@@ -187,13 +180,7 @@ class DistributedShampooGraftingTest(unittest.TestCase):
             optim_factory=experimental_optim_factory, device=device
         )
 
-    @parametrize(
-        "preconditioner_config",
-        (
-            DefaultShampooConfig,
-            EigendecomposedShampooPreconditionerConfig(),
-        ),
-    )
+    @parametrize("preconditioner_config", preconditioner_configs)
     @parametrize("device", available_devices)
     @parametrize("weight_decay", (0.0, 0.3))
     def test_rmsprop_grafting(
@@ -237,13 +224,7 @@ class DistributedShampooGraftingTest(unittest.TestCase):
             optim_factory=experimental_optim_factory, device=device
         )
 
-    @parametrize(
-        "preconditioner_config",
-        (
-            DefaultShampooConfig,
-            EigendecomposedShampooPreconditionerConfig(),
-        ),
-    )
+    @parametrize("preconditioner_config", preconditioner_configs)
     @parametrize("device", available_devices)
     @parametrize("use_nesterov", (True, False))
     @parametrize("weight_decay", (0.0, 0.3))

--- a/distributed_shampoo/preconditioner/matrix_functions_types.py
+++ b/distributed_shampoo/preconditioner/matrix_functions_types.py
@@ -45,7 +45,7 @@ DefaultPerturbationConfig = PerturbationConfig()
 @dataclass(kw_only=True)
 class PseudoInverseConfig(RankDeficientStabilityConfig):
     """
-    Configuration for filtering zero/near-zero singular values (i.e. determining rank) to return a pseudo-inverse when the matrix is non-invertible.
+    Configuration for filtering zero/near-zero singular values (i.e., determining rank) to return a pseudo-inverse when the matrix is non-invertible.
     For more information, refer to https://pytorch.org/docs/stable/generated/torch.linalg.matrix_rank.html.
 
     Attributes:


### PR DESCRIPTION
Summary: Even though none of those `preconditioner_config` plays any role in the test but it implicitly testing the part of config creation part.

Differential Revision: D81419589


